### PR TITLE
Remove mount layout animation check

### DIFF
--- a/packages/framer-motion/src/motion/features/layout/MeasureLayout.tsx
+++ b/packages/framer-motion/src/motion/features/layout/MeasureLayout.tsx
@@ -25,6 +25,12 @@ interface MeasureContextProps {
 type MeasureProps = MotionProps &
     MeasureContextProps & { visualElement: VisualElement }
 
+/**
+ * Track whether we've taken any snapshots yet. If not,
+ * we can safely skip notification of didUpdate.
+ */
+let hasTakenAnySnapshot = false
+
 class MeasureLayoutWithContext extends Component<MeasureProps> {
     /**
      * This only mounts projection nodes for components that
@@ -45,7 +51,10 @@ class MeasureLayoutWithContext extends Component<MeasureProps> {
                 switchLayoutGroup.register(projection)
             }
 
-            projection.root!.didUpdate()
+            if (hasTakenAnySnapshot) {
+                projection.root!.didUpdate()
+            }
+
             projection.addEventListener("animationComplete", () => {
                 this.safeToRemove()
             })
@@ -72,6 +81,8 @@ class MeasureLayoutWithContext extends Component<MeasureProps> {
          * perhaps in didUpdate
          */
         projection.isPresent = isPresent
+
+        hasTakenAnySnapshot = true
 
         if (
             drag ||

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -630,8 +630,10 @@ export function createProjectionNode<I>({
 
         // Note: currently only running on root node
         startUpdate() {
+            console.log("update blocked")
             if (this.isUpdateBlocked()) return
 
+            console.log("start update")
             this.isUpdating = true
 
             this.nodes && this.nodes.forEach(resetSkewAndRotation)
@@ -724,31 +726,31 @@ export function createProjectionNode<I>({
                 return
             }
 
-            if (!this.isUpdating) {
-                this.nodes!.forEach(clearIsLayoutDirty)
-                return
-            }
-
             this.animationCommitId = this.animationId
 
-            this.isUpdating = false
+            if (!this.isUpdating) {
+                this.nodes!.forEach(clearIsLayoutDirty)
+            } else {
+                this.isUpdating = false
 
-            /**
-             * Write
-             */
-            this.nodes!.forEach(resetTransformStyle)
+                /**
+                 * Write
+                 */
+                this.nodes!.forEach(resetTransformStyle)
 
-            /**
-             * Read ==================
-             */
-            // Update layout measurements of updated children
-            this.nodes!.forEach(updateLayout)
+                /**
+                 * Read ==================
+                 */
+                // Update layout measurements of updated children
+                this.nodes!.forEach(updateLayout)
 
-            /**
-             * Write
-             */
-            // Notify listeners that the layout is updated
-            this.nodes!.forEach(notifyLayoutUpdate)
+                /**
+                 * Write
+                 */
+                // Notify listeners that the layout is updated
+                this.nodes!.forEach(notifyLayoutUpdate)
+            }
+
             this.clearAllSnapshots()
 
             /**

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -630,10 +630,8 @@ export function createProjectionNode<I>({
 
         // Note: currently only running on root node
         startUpdate() {
-            console.log("update blocked")
             if (this.isUpdateBlocked()) return
 
-            console.log("start update")
             this.isUpdating = true
 
             this.nodes && this.nodes.forEach(resetSkewAndRotation)

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -645,6 +645,7 @@ export function createProjectionNode<I>({
 
         willUpdate(shouldNotifyListeners = true) {
             this.root.hasTreeAnimated = true
+
             if (this.root.isUpdateBlocked()) {
                 this.options.onExitComplete && this.options.onExitComplete()
                 return
@@ -767,7 +768,7 @@ export function createProjectionNode<I>({
         scheduleUpdate = () => this.update()
 
         didUpdate() {
-            if (!this.updateScheduled) {
+            if (this.isUpdating && !this.updateScheduled) {
                 this.updateScheduled = true
                 microtask.read(this.scheduleUpdate)
             }
@@ -857,15 +858,14 @@ export function createProjectionNode<I>({
         updateLayout() {
             if (!this.instance) return
 
-            // TODO: Incorporate into a forwarded scroll offset
-            this.updateScroll()
-
             if (
                 !(this.options.alwaysMeasureLayout && this.isLead()) &&
                 !this.isLayoutDirty
             ) {
                 return
             }
+
+            this.updateScroll()
 
             /**
              * When a node is mounted, it simply resumes from the prevLead's

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -726,6 +726,7 @@ export function createProjectionNode<I>({
 
             if (!this.isUpdating) {
                 this.nodes!.forEach(clearIsLayoutDirty)
+                return
             }
 
             this.animationCommitId = this.animationId
@@ -768,7 +769,7 @@ export function createProjectionNode<I>({
         scheduleUpdate = () => this.update()
 
         didUpdate() {
-            if (this.isUpdating && !this.updateScheduled) {
+            if (!this.updateScheduled) {
                 this.updateScheduled = true
                 microtask.read(this.scheduleUpdate)
             }

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -858,14 +858,14 @@ export function createProjectionNode<I>({
         updateLayout() {
             if (!this.instance) return
 
+            this.updateScroll()
+
             if (
                 !(this.options.alwaysMeasureLayout && this.isLead()) &&
                 !this.isLayoutDirty
             ) {
                 return
             }
-
-            this.updateScroll()
 
             /**
              * When a node is mounted, it simply resumes from the prevLead's


### PR DESCRIPTION
Currently, `MeasureLayout` calls `didUpdate` on mount because it could be the case that a layout animation has been triggered where all the snapshotted elements were removed during the render and nothing would be left to call it otherwise. This PR removes unused layout animation initialisations by checking if this happened before scheduling layout measurements.

It also ensures we only measure scroll when we take our first snapshot.