### PR TITLE
Changelog doesn't detail breaking changes that are causing downstream issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -709,6 +709,10 @@ Undocumented APIs should be considered internal and may change without warning.
 
 ## [11.0.0] 2024-01-23
 
+## Breaking
+
+-   glide has been removed. Users of glide can instead use type: "inertia" via the hybrid animate function.
+
 ### Changed
 
 -   Replaced velocity-check jobs in favour of passive detection.


### PR DESCRIPTION
So I'm using the livemotion elixir library but we maintain a custom integration with the motion library and we're noticing quite a few deprecations that happened in the v11 update that aren't reflected in the changelog.

I'm still trying to find the replacement for `createMotionState()` that was used.