### PR TITLE
Ensuring animations are set to `ease: "linear"` when passed to `scroll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [11.11.16] 2024-11-13
+
+### Fixed
+
+-   Ensuring animations passed to `scroll` are flattened.
+
 ## [11.11.15] 2024-11-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Undocumented APIs should be considered internal and may change without warning.
 
 ### Fixed
 
--   Ensuring animations passed to `scroll` are flattened.
+-   Ensuring animations passed to `scroll` are scrubbed linearly.
+-   Fixing `mini` types entrypoint.
 
 ## [11.11.15] 2024-11-13
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,9 @@ test-nextjs: build test-mkdir
 
 test-e2e: test-nextjs test-html test-react
 
+test-single: build test-mkdir
+	yarn start-server-and-test "yarn dev-server" http://localhost:9990 "cd packages/framer-motion && cypress run --headless --spec cypress/integration/scroll.ts"
+
 lint: bootstrap
 	yarn lint
 

--- a/dev/next/next-env.d.ts
+++ b/dev/next/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/dev/react/src/tests/scroll-animate-style.tsx
+++ b/dev/react/src/tests/scroll-animate-style.tsx
@@ -1,24 +1,28 @@
-import { scroll, useAnimateMini } from "framer-motion"
+import { scroll, useAnimateMini, animate } from "framer-motion"
 import * as React from "react"
 import { useEffect } from "react"
 
 export const App = () => {
-    const [scope, animate] = useAnimateMini()
+    const [scope, miniAnimate] = useAnimateMini()
 
     useEffect(() => {
         if (!scope.current) return
 
-        return scroll(
-            animate(
-                scope.current,
-                {
-                    backgroundColor: ["#fff", "#000"],
-                    color: ["#000", "#fff"],
-                    transform: ["none", "translateX(100px)"],
-                },
-                { ease: "linear" }
-            )
+        const stopMiniScrollAnimation = scroll(
+            miniAnimate(scope.current, {
+                backgroundColor: ["#fff", "#000"],
+                color: ["#000", "#fff"],
+            })
         )
+
+        const stopScrollAnimation = scroll(
+            animate(scope.current, { x: [0, 100] })
+        )
+
+        return () => {
+            stopMiniScrollAnimation()
+            stopScrollAnimation()
+        }
     }, [])
 
     return (

--- a/dev/react/src/tests/scroll-animate-window.tsx
+++ b/dev/react/src/tests/scroll-animate-window.tsx
@@ -5,21 +5,16 @@ import { useEffect } from "react"
 export const App = () => {
     useEffect(() => {
         const stopScrollAnimation = scroll(
-            animate(
-                "#color",
-                { x: [0, 100], backgroundColor: ["#fff", "#000"] },
-                { ease: "linear" }
-            )
+            animate("#color", {
+                x: [0, 100],
+                backgroundColor: ["#fff", "#000"],
+            })
         )
 
         const stopMiniScrollAnimation = scroll(
-            animateMini(
-                "#color",
-                {
-                    color: ["#000", "#fff"],
-                },
-                { ease: "linear" }
-            )
+            animateMini("#color", {
+                color: ["#000", "#fff"],
+            })
         )
 
         return () => {

--- a/dev/react/src/tests/scroll-animate-window.tsx
+++ b/dev/react/src/tests/scroll-animate-window.tsx
@@ -13,8 +13,6 @@ export const App = () => {
     const progress = useMotionValue(0)
 
     useEffect(() => {
-        console.log("Effect ============================")
-        console.log("x, opacity and background color")
         const stopScrollAnimation = scroll(
             animate("#color", {
                 x: [0, 100],
@@ -23,14 +21,12 @@ export const App = () => {
             })
         )
 
-        console.log("color")
         const stopMiniScrollAnimation = scroll(
             animateMini("#color", {
                 color: ["#000", "#fff"],
             })
         )
 
-        console.log("motion value")
         const stopMotionValueAnimation = scroll(animate(progress, 100))
 
         return () => {

--- a/dev/react/src/tests/scroll-animate-window.tsx
+++ b/dev/react/src/tests/scroll-animate-window.tsx
@@ -1,23 +1,31 @@
-import { scroll, animate } from "framer-motion"
+import { scroll, animate, animateMini } from "framer-motion"
 import * as React from "react"
 import { useEffect } from "react"
 
 export const App = () => {
     useEffect(() => {
-        /**
-         * Animate both transform (WAAPI) and colors (JS)
-         */
-        return scroll(
+        const stopScrollAnimation = scroll(
             animate(
                 "#color",
+                { x: [0, 100], backgroundColor: ["#fff", "#000"] },
+                { ease: "linear" }
+            )
+        )
+
+        const stopMiniScrollAnimation = scroll(
+            animateMini(
+                "#color",
                 {
-                    backgroundColor: ["#fff", "#000"],
                     color: ["#000", "#fff"],
-                    transform: ["none", "translateX(100px)"],
                 },
                 { ease: "linear" }
             )
         )
+
+        return () => {
+            stopScrollAnimation()
+            stopMiniScrollAnimation()
+        }
     }, [])
 
     return (

--- a/dev/react/src/tests/scroll-animate-window.tsx
+++ b/dev/react/src/tests/scroll-animate-window.tsx
@@ -1,27 +1,46 @@
-import { scroll, animate, animateMini } from "framer-motion"
+import {
+    scroll,
+    animate,
+    animateMini,
+    useMotionValue,
+    useTransform,
+    motion,
+} from "framer-motion"
 import * as React from "react"
 import { useEffect } from "react"
 
 export const App = () => {
+    const progress = useMotionValue(0)
+
     useEffect(() => {
+        console.log("Effect ============================")
+        console.log("x, opacity and background color")
         const stopScrollAnimation = scroll(
             animate("#color", {
                 x: [0, 100],
+                opacity: [0, 1],
                 backgroundColor: ["#fff", "#000"],
             })
         )
 
+        console.log("color")
         const stopMiniScrollAnimation = scroll(
             animateMini("#color", {
                 color: ["#000", "#fff"],
             })
         )
 
+        console.log("motion value")
+        const stopMotionValueAnimation = scroll(animate(progress, 100))
+
         return () => {
             stopScrollAnimation()
             stopMiniScrollAnimation()
+            stopMotionValueAnimation()
         }
     }, [])
+
+    const progressDisplay = useTransform(() => Math.round(progress.get()))
 
     return (
         <>
@@ -29,9 +48,9 @@ export const App = () => {
             <div style={{ ...spacer, backgroundColor: "green" }} />
             <div style={{ ...spacer, backgroundColor: "blue" }} />
             <div style={{ ...spacer, backgroundColor: "yellow" }} />
-            <div id="color" style={progressStyle}>
-                A
-            </div>
+            <motion.div id="color" style={progressStyle}>
+                {progressDisplay}
+            </motion.div>
         </>
     )
 }

--- a/packages/framer-motion/cypress/integration/scroll.ts
+++ b/packages/framer-motion/cypress/integration/scroll.ts
@@ -105,12 +105,17 @@ describe("scroll() animation", () => {
             .wait(200)
             .get("#color")
             .should(([$element]: any) => {
+                // This is animated by animate and thus uses linear RGB mixing
                 expect(getComputedStyle($element).backgroundColor).to.equal(
                     "rgb(180, 180, 180)"
                 )
+
+                // This is animated by animate mini and thus doesn't use linear RGB mixing
                 expect(getComputedStyle($element).color).to.equal(
-                    "rgb(180, 180, 180)"
+                    "rgb(128, 128, 128)"
                 )
+
+                expect($element.style.transform).to.equal("translateX(50px)")
             })
         cy.viewport(100, 800)
             .wait(200)
@@ -120,7 +125,7 @@ describe("scroll() animation", () => {
                     "rgb(221, 221, 221)"
                 )
                 expect(getComputedStyle($element).color).to.equal(
-                    "rgb(128, 128, 128)"
+                    "rgb(64, 64, 64)"
                 )
             })
     })

--- a/packages/framer-motion/cypress/integration/scroll.ts
+++ b/packages/framer-motion/cypress/integration/scroll.ts
@@ -117,6 +117,8 @@ describe("scroll() animation", () => {
 
                 expect(getComputedStyle($element).opacity).to.equal("0.5")
                 expect($element.style.transform).to.equal("translateX(50px)")
+
+                expect($element.innerText).to.equal("50")
             })
         cy.viewport(100, 800)
             .wait(200)

--- a/packages/framer-motion/cypress/integration/scroll.ts
+++ b/packages/framer-motion/cypress/integration/scroll.ts
@@ -115,6 +115,7 @@ describe("scroll() animation", () => {
                     "rgb(128, 128, 128)"
                 )
 
+                expect(getComputedStyle($element).opacity).to.equal("0.5")
                 expect($element.style.transform).to.equal("translateX(50px)")
             })
         cy.viewport(100, 800)

--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -86,6 +86,10 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
         this.animations.forEach((controls) => controls[methodName]())
     }
 
+    flatten() {
+        this.runAll("flatten")
+    }
+
     play() {
         this.runAll("play")
     }

--- a/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
+++ b/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
@@ -15,6 +15,7 @@ function createTestAnimationControls(
         then: (resolve: VoidFunction) => {
             return Promise.resolve().then(resolve)
         },
+        flatten: () => {},
         complete: () => {},
         cancel: () => {},
         ...partialControls,

--- a/packages/framer-motion/src/animation/animators/BaseAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/BaseAnimation.ts
@@ -205,7 +205,6 @@ export abstract class BaseAnimation<T extends string | number, Resolved>
     }
 
     flatten() {
-        console.log("flatten")
         this.options.type = "keyframes"
         this.options.ease = "linear"
     }

--- a/packages/framer-motion/src/animation/animators/BaseAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/BaseAnimation.ts
@@ -204,6 +204,12 @@ export abstract class BaseAnimation<T extends string | number, Resolved>
         return this.currentFinishedPromise.then(resolve, reject)
     }
 
+    flatten() {
+        console.log("flatten")
+        this.options.type = "keyframes"
+        this.options.ease = "linear"
+    }
+
     protected updateFinishedPromise() {
         this.currentFinishedPromise = new Promise((resolve) => {
             this.resolveFinishedPromise = resolve

--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -133,11 +133,12 @@ export class MainThreadAnimation<
     flatten() {
         super.flatten()
 
+        // If we've already resolved the animation, re-initialise it
         if (this._resolved) {
-            this._resolved = {
-                ...this._resolved,
-                ...this.initPlayback(this._resolved.keyframes),
-            }
+            Object.assign(
+                this._resolved,
+                this.initPlayback(this._resolved.keyframes)
+            )
         }
     }
 

--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -130,6 +130,17 @@ export class MainThreadAnimation<
         this.resolver.scheduleResolve()
     }
 
+    flatten() {
+        super.flatten()
+
+        if (this._resolved) {
+            this._resolved = {
+                ...this._resolved,
+                ...this.initPlayback(this._resolved.keyframes),
+            }
+        }
+    }
+
     protected initPlayback(keyframes: ResolvedKeyframes<T>) {
         const {
             type = "keyframes",

--- a/packages/framer-motion/src/animation/animators/waapi/NativeAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/NativeAnimation.ts
@@ -201,6 +201,12 @@ export class NativeAnimation implements AnimationPlaybackControls {
         return this.animation ? (this.animation.startTime as number) : null
     }
 
+    flatten() {
+        if (!this.animation) return
+
+        this.animation.effect?.updateTiming({ easing: "linear" })
+    }
+
     play() {
         if (this.state === "finished") {
             this.updateFinishedPromise()

--- a/packages/framer-motion/src/animation/animators/waapi/animate-style.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/animate-style.ts
@@ -1,5 +1,6 @@
 import { GroupPlaybackControls } from "../../GroupPlaybackControls"
 import {
+    AnimationPlaybackControls,
     AnimationScope,
     DOMKeyframesDefinition,
     DynamicAnimationOptions,
@@ -12,7 +13,7 @@ export const createScopedWaapiAnimate = (scope?: AnimationScope) => {
         elementOrSelector: ElementOrSelector,
         keyframes: DOMKeyframesDefinition,
         options?: DynamicAnimationOptions
-    ) {
+    ): AnimationPlaybackControls {
         return new GroupPlaybackControls(
             animateElements(
                 elementOrSelector,

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -137,6 +137,7 @@ export interface AnimationPlaybackControls {
         timeline: ProgressTimeline,
         fallback?: (animation: AnimationPlaybackControls) => VoidFunction
     ) => VoidFunction
+    flatten: () => void
 }
 
 export type DynamicOption<T> = (i: number, total: number) => T

--- a/packages/framer-motion/src/render/dom/scroll/index.ts
+++ b/packages/framer-motion/src/render/dom/scroll/index.ts
@@ -98,6 +98,8 @@ function scrollAnimation(
     animation: AnimationPlaybackControls,
     options: ScrollOptions
 ) {
+    animation.flatten()
+
     if (needsElementTracking(options)) {
         animation.pause()
         return scrollInfo((info) => {

--- a/packages/framer-motion/src/render/dom/scroll/index.ts
+++ b/packages/framer-motion/src/render/dom/scroll/index.ts
@@ -1,8 +1,9 @@
 import { ScrollOptions, OnScroll, OnScrollWithInfo } from "./types"
 import { scrollInfo } from "./track"
-import { GroupPlaybackControls } from "../../../animation/GroupPlaybackControls"
 import { ProgressTimeline, observeTimeline } from "./observe"
 import { supportsScrollTimeline } from "./supports"
+import { AnimationPlaybackControls } from "../../../animation/types"
+import { noop } from "../../../utils/noop"
 
 declare class ScrollTimeline implements ProgressTimeline {
     constructor(options: ScrollOptions)
@@ -94,7 +95,7 @@ function scrollFunction(onScroll: OnScroll, options: ScrollOptions) {
 }
 
 function scrollAnimation(
-    animation: GroupPlaybackControls,
+    animation: AnimationPlaybackControls,
     options: ScrollOptions
 ) {
     if (needsElementTracking(options)) {
@@ -105,18 +106,22 @@ function scrollAnimation(
     } else {
         const timeline = getTimeline(options)
 
-        return animation.attachTimeline(timeline, (valueAnimation) => {
-            valueAnimation.pause()
+        if (animation.attachTimeline) {
+            return animation.attachTimeline(timeline, (valueAnimation) => {
+                valueAnimation.pause()
 
-            return observeTimeline((progress) => {
-                valueAnimation.time = valueAnimation.duration * progress
-            }, timeline)
-        })
+                return observeTimeline((progress) => {
+                    valueAnimation.time = valueAnimation.duration * progress
+                }, timeline)
+            })
+        } else {
+            return noop as VoidFunction
+        }
     }
 }
 
 export function scroll(
-    onScroll: OnScroll | GroupPlaybackControls,
+    onScroll: OnScroll | AnimationPlaybackControls,
     { axis = "y", ...options }: ScrollOptions = {}
 ): VoidFunction {
     const optionsWithDefaults = { axis, ...options }

--- a/packages/motion/rollup.config.mjs
+++ b/packages/motion/rollup.config.mjs
@@ -154,11 +154,29 @@ const reactTypes = {
     plugins: typePlugins,
 }
 
+const miniTypes = {
+    input: "types/mini.d.ts",
+    output: {
+        format: "es",
+        file: "dist/mini.d.ts",
+    },
+    plugins: typePlugins,
+}
+
 const mTypes = {
     input: "types/react-m.d.ts",
     output: {
         format: "es",
         file: "dist/react-m.d.ts",
+    },
+    plugins: typePlugins,
+}
+
+const reactMiniTypes = {
+    input: "types/react-mini.d.ts",
+    output: {
+        format: "es",
+        file: "dist/react-mini.d.ts",
     },
     plugins: typePlugins,
 }
@@ -185,6 +203,8 @@ export default [
     es,
     types,
     reactTypes,
+    reactMiniTypes,
     mTypes,
+    miniTypes,
     clientTypes,
 ]


### PR DESCRIPTION
Fixes https://github.com/motiondivision/motion/issues/2868

This restores the behaviour from Motion One, which is more expected than the current behaviour in Motion where the existing easing/spring is preserved.

Drive-by fix for `mini` entrypoint.
Fixes https://github.com/motiondivision/motion/issues/2865