### PR TITLE
Fixing easing exports

### DIFF
--- a/packages/framer-motion/src/dom.ts
+++ b/packages/framer-motion/src/dom.ts
@@ -17,6 +17,7 @@ export * from "./easing/cubic-bezier"
 export * from "./easing/steps"
 export * from "./easing/modifiers/mirror"
 export * from "./easing/modifiers/reverse"
+export * from "./easing/types"
 
 /**
  * Animation generators

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -150,7 +150,6 @@ export {
     Variant,
     Variants,
 } from "./types"
-export * from "./easing/types"
 export { EventInfo } from "./events/types"
 export * from "./motion/features/types"
 export {


### PR DESCRIPTION
This PR ensures easing types are exported via `"motion"`

Fixes https://github.com/motiondivision/motion/issues/2872