### PR TITLE
fix: export render html utils

### DIFF
--- a/packages/framer-motion/src/dom.ts
+++ b/packages/framer-motion/src/dom.ts
@@ -40,6 +40,8 @@ export { pipe } from "./utils/pipe"
 export { progress } from "./utils/progress"
 export { wrap } from "./utils/wrap"
 export * from "./frameloop"
+export {buildHTMLStyles} from "./render/html/utils/build-styles"
+export {buildTransform} from "./render/html/utils/build-transform"
 
 /**
  * Deprecated


### PR DESCRIPTION
close #2875 

This pull request includes updates to the `packages/framer-motion/src/dom.ts` file to improve the export functionality. The most important changes include the addition of new exports from the `render/html/utils` directory.

Export functionality improvements:

* [`packages/framer-motion/src/dom.ts`](diffhunk://#diff-1b2fd64e4dff7dcd1a5ef6d4236645330f2583528bb37614a818dedde028f993R43-R44): Added `buildHTMLStyles` and `buildTransform` to the list of exports.