### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Motion powers Framer animations, the web builder for creative pros. Design and s
 
 <a href="https://www.frontend.fyi/?utm_source=motion"><img alt="Frontend.fyi" src="https://github.com/user-attachments/assets/07d23aa5-69db-44a0-849d-90177e6fc817" width="150px" height="100px"></a>
 
-<a href="https://www.frontend.fyi/?utm_source=motion"><img alt="Statamic" src="https://github.com/user-attachments/assets/5d28f090-bdd9-4b31-b134-fb2b94ca636f" width="150px" height="100px"></a>
+<a href="https://statamic.com"><img alt="Statamic" src="https://github.com/user-attachments/assets/5d28f090-bdd9-4b31-b134-fb2b94ca636f" width="150px" height="100px"></a>
 
 <a href="https://firecrawl.dev"><img alt="Firecrawl" src="https://github.com/user-attachments/assets/cba90e54-1329-4353-8fba-85beef4d2ee9" width="150px" height="100px"></a>
 

--- a/packages/framer-motion/README.md
+++ b/packages/framer-motion/README.md
@@ -38,14 +38,14 @@ It does all this:
 
 -   [Springs](https://motion.dev/docs/react-transitions#spring)
 -   [Keyframes](https://motion.dev/docs/react-animation#keyframes)
--   [Layout animations](https://motion/dev/docs/react-layout-animations)
+-   [Layout animations](https://motion.dev/docs/react-layout-animations)
 -   [Shared layout animations](https://motion.dev/docs/react-layout-animations#shared-layout-animations)
 -   [Gestures (drag/tap/hover)](https://motion.dev/docs/react-gestures)
 -   [Scroll animations](https://motion.dev/docs/react-scroll-animations)
 -   [SVG paths](https://motion.dev/docs/react-animation#svg-line-drawing)
 -   [Exit animations](https://motion.dev/docs/react-animation#exit-animations)
--   [Server-side rendering](https://motion.dev//docs/react-motion-component#server-side-rendering)
--   [Independent transforms](https://motion.dev/docs/react-motion-component#independent-transforms)
+-   [Server-side rendering](https://motion.dev/docs/react-motion-component#server-side-rendering)
+-   [Independent transforms](https://motion.dev/docs/react-motion-component#style)
 -   [Orchestrate animations across components](https://motion.dev/docs/react-animation#orchestration)
 -   [CSS variables](https://motion.dev/docs/react-animation#css-variables)
 

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -38,14 +38,14 @@ It does all this:
 
 -   [Springs](https://motion.dev/docs/react-transitions#spring)
 -   [Keyframes](https://motion.dev/docs/react-animation#keyframes)
--   [Layout animations](https://motion/dev/docs/react-layout-animations)
+-   [Layout animations](https://motion.dev/docs/react-layout-animations)
 -   [Shared layout animations](https://motion.dev/docs/react-layout-animations#shared-layout-animations)
 -   [Gestures (drag/tap/hover)](https://motion.dev/docs/react-gestures)
 -   [Scroll animations](https://motion.dev/docs/react-scroll-animations)
 -   [SVG paths](https://motion.dev/docs/react-animation#svg-line-drawing)
 -   [Exit animations](https://motion.dev/docs/react-animation#exit-animations)
--   [Server-side rendering](https://motion.dev//docs/react-motion-component#server-side-rendering)
--   [Independent transforms](https://motion.dev/docs/react-motion-component#independent-transforms)
+-   [Server-side rendering](https://motion.dev/docs/react-motion-component#server-side-rendering)
+-   [Independent transforms](https://motion.dev/docs/react-motion-component#style)
 -   [Orchestrate animations across components](https://motion.dev/docs/react-animation#orchestration)
 -   [CSS variables](https://motion.dev/docs/react-animation#css-variables)
 


### PR DESCRIPTION
This PR fixes some broken links in the README files:

- Updated partner link to point to [statamic.com](https://statamic.com/).
- Fix broken links in docs
  - Corrected typos in URLs
  - Updated the link for "independent transforms" to point to the [`style`](https://motion.dev/docs/react-motion-component#style) section of the React Motion component. This section seems the most appropriate to me. If this is not the correct section, please let me know, and I will update it accordingly.