### PR TITLE
Updating three and @react-three/fiber to latest versions

### DIFF
--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -49,16 +49,16 @@
         "react-merge-refs": "^2.0.1"
     },
     "peerDependencies": {
-        "@react-three/fiber": "8.2.2",
+        "@react-three/fiber": ">=8.17.10",
         "react": ">=18.0",
         "react-dom": ">=18.0",
-        "three": ">=0.133"
+        "three": ">=0.170.0"
     },
     "devDependencies": {
-        "@react-three/fiber": "8.2.2",
+        "@react-three/fiber": "^8.17.10",
         "@react-three/test-renderer": "^9.0.0",
         "@rollup/plugin-commonjs": "^22.0.1",
-        "three": "^0.137.0"
+        "three": "^0.170.0"
     },
     "gitHead": "eeb1cc452e2b468d838ec76fd501b131b383c5c9"
 }


### PR DESCRIPTION
Upgrading both peerDependencies for three and @react-three/fiber to the latest versions, and removing the hardcoded restriction for @react-three/fiber to be fixed to version 8.2.2