### PR TITLE
Adding missing types to the dom.ts file

### DIFF
--- a/packages/framer-motion/src/dom.ts
+++ b/packages/framer-motion/src/dom.ts
@@ -46,6 +46,14 @@ export { wrap } from "./utils/wrap"
 export * from "./frameloop"
 
 /**
+ * Types
+ */
+
+export * from "./animation/types"
+export * from "./animation/sequence/types"
+export * from "./projection/geometry/types"
+
+/**
  * Deprecated
  */
 export { sync, cancelSync } from "./frameloop/index-legacy"


### PR DESCRIPTION
From what I can tell, the imports added would fix the typescript import errors. I'm not sure if I 100% avoided the react imports, but this is a general start to fixing the missing types bug for non-react projects.

Please make all the edits you need. Just a suggestion, possibly separate the react only types from the others either with spacing.comments or files. It'll be a headache in the future to keep track of everything. 

Personally I'd put all of my types in a folder, with each specific type having it's own folder. At the base of the types folder I'd have an index.ts consuming all the types. Then I'd place a reactTypes folder in there, consume all of the regular types you'd need from types/index. That way you could import all of the regular types and react only types when needed. 