### PR TITLE
Adds missing license information for framer-dom and framer-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [11.14.1] 2024-12-12
+
+### Fixed
+
+-   Added missing license information in `"framer-dom"` and `"framer-until"` in `"package.json"`.
+
 ## [11.14.0] 2024-12-12
 
 ### Added

--- a/packages/motion-dom/package.json
+++ b/packages/motion-dom/package.json
@@ -1,6 +1,7 @@
 {
     "name": "motion-dom",
     "version": "11.14.0",
+    "license": "MIT",
     "main": "./lib/index.js",
     "types": "./types/index.d.ts",
     "module": "./lib/index.js",

--- a/packages/motion-utils/package.json
+++ b/packages/motion-utils/package.json
@@ -1,6 +1,7 @@
 {
     "name": "motion-utils",
     "version": "11.13.0",
+    "license": "MIT",
     "main": "./lib/index.js",
     "types": "./types/index.d.ts",
     "module": "./lib/index.js",


### PR DESCRIPTION
Adds missing license information in `"framer-dom"` and `"framer-utils"` in `"package.json"`. Fixes #2939 