### PR TITLE
Fix a potential memory leak if a render step pauses for a long time.

### DIFF
--- a/packages/framer-motion/src/frameloop/render-step.ts
+++ b/packages/framer-motion/src/frameloop/render-step.ts
@@ -86,6 +86,10 @@ export function createRenderStep(runNextFrame: () => void): Step {
             // Execute this frame
             thisFrame.forEach(triggerCallback)
 
+            // Clear the just processed frame, so we don't retain anything the callbacks retain,
+            // incase this step will not run for a while.
+            thisFrame.clear()
+
             isProcessing = false
 
             if (flushNextFrame) {


### PR DESCRIPTION
Motion can hold on to user memory, potentially for a long time, if a render step doesn't have work to do for a long while.

This caused some trouble for us, where through callbacks and closures, this would hold on to old tree data, after a tree was reloaded from the server. Doubling memory use.

![image](https://github.com/user-attachments/assets/580e9dc7-0637-4ed2-b8fa-4713af88212d)

This PR simply clears the `thisFrame` set the moment it is no longer needed. Fixing the problem for us.