### PR TITLE
`transition.out`

### DIFF
--- a/dev/react/src/examples/Animation-transition-out.tsx
+++ b/dev/react/src/examples/Animation-transition-out.tsx
@@ -1,0 +1,29 @@
+import { motion } from "framer-motion"
+import { useEffect, useState } from "react"
+
+/**
+ * An example of the tween transition type
+ */
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "white",
+}
+export const App = () => {
+    const [state, setState] = useState(false)
+    useEffect(() => {
+        setTimeout(() => {
+            setState(true)
+        }, 300)
+    }, [state])
+
+    return (
+        <motion.div
+            animate={{ scale: 1, transition: { duration: 1 } }}
+            whileHover={{ scale: 1.1, transition: { duration: 1 } }}
+            whileTap={{ scale: 0.9, transition: { out: true, type: false } }}
+            style={style}
+        />
+    )
+}

--- a/packages/framer-motion/src/animation/interfaces/visual-element-target.ts
+++ b/packages/framer-motion/src/animation/interfaces/visual-element-target.ts
@@ -5,7 +5,7 @@ import type { TargetAndTransition } from "../../types"
 import type { VisualElementAnimationOptions } from "./types"
 import { animateMotionValue } from "./motion-value"
 import { setTarget } from "../../render/utils/setters"
-import { AnimationPlaybackControls } from "../types"
+import { AnimationPlaybackControls, Transition } from "../types"
 import { getValueTransition } from "../utils/get-value-transition"
 import { frame } from "../../frameloop"
 import { getOptimisedAppearId } from "../optimized-appear/get-appear-id"
@@ -63,9 +63,25 @@ export function animateTarget(
             continue
         }
 
-        const valueTransition = {
+        let valueTransition = {
             delay,
             ...getValueTransition(transition || {}, key),
+        }
+
+        let outTransition: Transition | undefined
+
+        if (type && value.nextTransition) {
+            outTransition = value.nextTransition
+        }
+
+        value.nextTransition = undefined
+
+        if (valueTransition.out) {
+            value.nextTransition = valueTransition
+        }
+
+        if (outTransition) {
+            valueTransition = outTransition
         }
 
         /**

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -44,6 +44,33 @@ export interface Transition
     duration?: number
     autoplay?: boolean
     startTime?: number
+
+    /**
+     * If set to `true`, when the animated value leaves its current
+     * state, this transition will be used.
+     *
+     * For example:
+     *
+     * ```jsx
+     * <motion.div
+     *   animate={{
+     *     opacity: 0,
+     *     transition: { delay: 1 }
+     *   }}
+     *   whileHover={{
+     *     opacity: 1,
+     *     transition: { out: true, duration: 1 }
+     *   }}
+     * />
+     * ```
+     *
+     * Because `whileHover` has a `transition` where `out` is `true`,
+     * when the hover ends, the `duration: 1` transition will be used,
+     * with no `delay`.
+     *
+     * @default false
+     */
+    out?: boolean
 }
 
 export interface ValueAnimationTransition<V = any>

--- a/packages/framer-motion/src/motion/__tests__/transition-out.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/transition-out.test.tsx
@@ -1,0 +1,85 @@
+import { render } from "../../../jest.setup"
+import { motion } from "framer-motion"
+import { fireEvent } from "@testing-library/react"
+import { nextFrame } from "../../gestures/__tests__/utils"
+
+describe("transition.out", () => {
+    it("uses whileHover transition when exiting hover state", async () => {
+        const onComplete = jest.fn()
+
+        const { container } = render(
+            <motion.div
+                animate={{ opacity: 0, transition: { duration: 1 } }}
+                transition={{ duration: 1 }}
+                onAnimationComplete={onComplete}
+                whileHover={{
+                    opacity: 1,
+                    transition: {
+                        type: false,
+                        out: true,
+                        onComplete,
+                    },
+                }}
+            />
+        )
+
+        // Enter hover
+        fireEvent.mouseEnter(container.firstChild!)
+
+        await nextFrame()
+
+        // Exit hover - should use whileHover transition with type: false
+        fireEvent.mouseLeave(container.firstChild!)
+
+        // Wait for animation to complete
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        expect(onComplete).toHaveBeenCalled()
+    })
+
+    it("uses whileTap out transition when tap ends before hover", async () => {
+        const onComplete = jest.fn()
+
+        const { container } = render(
+            <motion.div
+                whileHover={{
+                    scale: 1.1,
+                    transition: { duration: 1 },
+                }}
+                whileTap={{
+                    scale: 0.9,
+                    transition: {
+                        type: false,
+                        out: true,
+                        onComplete,
+                    },
+                }}
+                onAnimationComplete={onComplete}
+            />
+        )
+
+        // Enter hover
+        fireEvent.mouseEnter(container.firstChild!)
+
+        await nextFrame()
+
+        // Start tap
+        fireEvent.mouseDown(container.firstChild!)
+
+        await nextFrame()
+
+        // End tap before ending hover
+        fireEvent.mouseUp(container.firstChild!)
+
+        await nextFrame()
+
+        // Wait a frame to ensure animation has completed
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        // Should use whileTap out transition which is instant
+        expect(onComplete).toHaveBeenCalled()
+
+        // End hover
+        fireEvent.mouseLeave(container.firstChild!)
+    })
+})

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -2,7 +2,7 @@ import { frame } from "../frameloop"
 import { SubscriptionManager } from "../utils/subscription-manager"
 import { velocityPerSecond } from "../utils/velocity-per-second"
 import { warnOnce } from "../utils/warn-once"
-import { AnimationPlaybackControls } from "../animation/types"
+import { AnimationPlaybackControls, Transition } from "../animation/types"
 import { time } from "../frameloop/sync-time"
 
 export type Transformer<T> = (v: T) => T
@@ -98,6 +98,12 @@ export class MotionValue<V = any> {
      * The time `prevFrameValue` was updated.
      */
     prevUpdatedAt: number | undefined
+
+    /**
+     * A transition that should be applied to the next animation.
+     * This is used to handle the `out` transition option.
+     */
+    nextTransition?: Transition
 
     /**
      * Add a passive effect to this `MotionValue`.


### PR DESCRIPTION
This PR adds a new `out` option to `Transition`. When `true`, this transition will be used when the value animates out of its current state.

```jsx
<motion.div
  initial={{ y: 20 }}
  animate={{ y: 0, transition: { delay: 1 } }}
  whileHover={{ y: 2, transition: { out: true } }} // whileHover -> animate = no delay!
/> 
```

Closes https://github.com/motiondivision/motion/issues/1725