### PR TITLE
Updating R3F and Three to latest version; fixing associated types

### DIFF
--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -49,16 +49,16 @@
         "react-merge-refs": "^2.0.1"
     },
     "peerDependencies": {
-        "@react-three/fiber": "8.2.2",
+        "@react-three/fiber": ">=8.17.12",
         "react": ">=18.0",
         "react-dom": ">=18.0",
-        "three": ">=0.133"
+        "three": ">=0.139.0"
     },
     "devDependencies": {
-        "@react-three/fiber": "8.2.2",
+        "@react-three/fiber": "^8.17.12",
         "@react-three/test-renderer": "^9.0.0",
         "@rollup/plugin-commonjs": "^22.0.1",
-        "three": "^0.137.0"
+        "three": "^0.139.0"
     },
     "gitHead": "9c70b0208d6492d195ce5fdb60ded6cae1a3245c"
 }

--- a/packages/framer-motion-3d/src/render/create-visual-element.ts
+++ b/packages/framer-motion-3d/src/render/create-visual-element.ts
@@ -14,6 +14,10 @@ import { scrapeMotionValuesFromProps } from "./utils/scrape-motion-value"
 
 export const createRenderState = () => ({})
 
+function hasId(obj: any): obj is { id: number } {
+    return "id" in obj && typeof obj.id === "number"
+}
+
 export class ThreeVisualElement extends VisualElement<
     Object3DNode<any, any>,
     ThreeRenderState,
@@ -33,7 +37,10 @@ export class ThreeVisualElement extends VisualElement<
         a: Object3DNode<any, any>,
         b: Object3DNode<any, any>
     ) {
-        return a.id - b.id
+        if (hasId(a) && hasId(b)) {
+            return a.id - b.id
+        }
+        return 0
     }
 
     removeValueFromRenderState() {}

--- a/packages/framer-motion-3d/src/render/utils/read-value.ts
+++ b/packages/framer-motion-3d/src/render/utils/read-value.ts
@@ -4,7 +4,7 @@ import { Color } from "three"
 const readVector =
     (name: string, defaultValue: number) =>
     (axis: "x" | "y" | "z") =>
-    (instance: Object3DNode<any, any>) => {
+    (instance: Record<string, any>) => {
         const value = instance[name]
         return value ? value[axis] : defaultValue
     }
@@ -42,7 +42,7 @@ function readAnimatableValue(value?: Color) {
     }
 }
 
-export function readThreeValue(instance: Object3DNode<any, any>, name: string) {
+export function readThreeValue(instance: Record<string, any>, name: string) {
     return name in readers
         ? readers[name](instance)
         : readAnimatableValue(instance[name]) || 0

--- a/packages/framer-motion-3d/src/render/utils/set-value.ts
+++ b/packages/framer-motion-3d/src/render/utils/set-value.ts
@@ -5,7 +5,7 @@ import { ThreeRenderState } from "../../types"
 const setVector =
     (name: string, defaultValue: number) =>
     (i: number) =>
-    (instance: Object3DNode<any, any>, value: number) => {
+    (instance: Record<string, any>, value: number) => {
         if (instance[name] === undefined) {
             instance[name] = new Vector3(defaultValue)
         }
@@ -16,7 +16,7 @@ const setVector =
 const setEuler =
     (name: string, defaultValue: number) =>
     (axis: "x" | "y" | "z") =>
-    (instance: Object3DNode<any, any>, value: number) => {
+    (instance: Record<string, any>, value: number) => {
         if (instance[name] === undefined) {
             instance[name] = new Euler(defaultValue)
         }
@@ -25,7 +25,7 @@ const setEuler =
     }
 
 const setColor =
-    (name: string) => (instance: Object3DNode<any, any>, value: string) => {
+    (name: string) => (instance: Record<string, any>, value: string) => {
         if (instance[name] === undefined) {
             instance[name] = new Color(value)
         }


### PR DESCRIPTION
Updates dep + peer dep versions.
There's currently usage of `Object3DNode<any, any>`, which was throwing type errors with the new version and was not actually providing any type safety in many cases. Those have been replaced with `Record<string, any>`, though I don't think that's the long term solution.