### PR TITLE
Slightly improve types perf

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,9 @@
     "rules": {
         "@typescript-eslint/no-unused-vars": "warn",
         "@typescript-eslint/type-annotation-spacing": "error",
+        "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+        "@typescript-eslint/explicit-module-boundary-types": "warn",
+
         "react/jsx-pascal-case": "error",
         "react-compiler/react-compiler": "warn",
 

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -71,13 +71,16 @@ export interface CustomStyles {
     image?: string
 }
 
-export type MakeMotion<T> = MakeCustomValueType<{
-    [K in keyof T]:
-        | T[K]
-        | MotionValue<number>
-        | MotionValue<string>
-        | MotionValue<any> // A permissive type for Custom value types
-}>
+type MotionValueString = MotionValue<string>
+type MotionValueNumber = MotionValue<number>
+// type MotionValueAny = MotionValue<any>
+// type AMotionValue = MotionValueNumber | MotionValueString | MotionValueAny // any creates a permissive type for Custom value types
+
+type MakeMotionHelper<T> = {
+    [K in keyof T]: T[K] | MotionValue<T[K]>
+}
+
+export type MakeMotion<T> = MakeCustomValueType<MakeMotionHelper<T>>
 
 export type MotionCSS = MakeMotion<
     Omit<CSSProperties, "rotate" | "scale" | "perspective">
@@ -92,10 +95,10 @@ export type MotionTransform = MakeMotion<TransformProperties>
  * TODO: Currently unused, would like to reimplement with the ability
  * to still accept React.CSSProperties.
  */
-export type MotionCSSVariables = {
+export interface MotionCSSVariables {
     [key: `--${string}`]:
-        | MotionValue<number>
-        | MotionValue<string>
+        | MotionValueNumber
+        | MotionValueString
         | string
         | number
 }
@@ -103,10 +106,11 @@ export type MotionCSSVariables = {
 /**
  * @public
  */
-export type MotionStyle = MotionCSS &
-    MotionTransform &
-    MakeMotion<SVGPathProperties> &
-    MakeCustomValueType<CustomStyles>
+export interface MotionStyle
+    extends MotionCSS,
+        MotionTransform,
+        MakeMotion<SVGPathProperties>,
+        MakeCustomValueType<CustomStyles> {}
 
 export type OnUpdate = (v: Target) => void
 
@@ -261,8 +265,8 @@ export interface MotionAdvancedProps {
     ignoreStrict?: boolean
 }
 
-type ExternalMotionValues = {
-    [key: string]: MotionValue<number> | MotionValue<string>
+interface ExternalMotionValues {
+    [key: string]: MotionValueNumber | MotionValueString
 }
 
 /**

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -8,6 +8,7 @@ import {
     TargetAndTransition,
     Omit,
     MakeCustomValueType,
+    stringOrNumber,
 } from "../types"
 import { DraggableProps } from "../gestures/drag/types"
 import { LayoutProps } from "./features/layout/types"
@@ -27,28 +28,28 @@ import { ViewportProps } from "./features/viewport/types"
 export type VariantLabels = string | string[]
 
 export interface TransformProperties {
-    x?: string | number
-    y?: string | number
-    z?: string | number
-    translateX?: string | number
-    translateY?: string | number
-    translateZ?: string | number
-    rotate?: string | number
-    rotateX?: string | number
-    rotateY?: string | number
-    rotateZ?: string | number
-    scale?: string | number
-    scaleX?: string | number
-    scaleY?: string | number
-    scaleZ?: string | number
-    skew?: string | number
-    skewX?: string | number
-    skewY?: string | number
-    originX?: string | number
-    originY?: string | number
-    originZ?: string | number
-    perspective?: string | number
-    transformPerspective?: string | number
+    x?: stringOrNumber
+    y?: stringOrNumber
+    z?: stringOrNumber
+    translateX?: stringOrNumber
+    translateY?: stringOrNumber
+    translateZ?: stringOrNumber
+    rotate?: stringOrNumber
+    rotateX?: stringOrNumber
+    rotateY?: stringOrNumber
+    rotateZ?: stringOrNumber
+    scale?: stringOrNumber
+    scaleX?: stringOrNumber
+    scaleY?: stringOrNumber
+    scaleZ?: stringOrNumber
+    skew?: stringOrNumber
+    skewX?: stringOrNumber
+    skewY?: stringOrNumber
+    originX?: stringOrNumber
+    originY?: stringOrNumber
+    originZ?: stringOrNumber
+    perspective?: stringOrNumber
+    transformPerspective?: stringOrNumber
 }
 
 /**
@@ -65,22 +66,24 @@ export interface CustomStyles {
      * Framer Library custom prop types. These are not actually supported in Motion - preferably
      * we'd have a way of external consumers injecting supported styles into this library.
      */
-    size?: string | number
-    radius?: string | number
+    size?: stringOrNumber
+    radius?: stringOrNumber
     shadow?: string
     image?: string
 }
 
 type MotionValueString = MotionValue<string>
 type MotionValueNumber = MotionValue<number>
-// type MotionValueAny = MotionValue<any>
-// type AMotionValue = MotionValueNumber | MotionValueString | MotionValueAny // any creates a permissive type for Custom value types
+type MotionValueAny = MotionValue<any>
+type AMotionValue = MotionValueNumber | MotionValueString | MotionValueAny // any creates a permissive type for Custom value types
 
+type MotionValueHelper<T> = T | AMotionValue
 type MakeMotionHelper<T> = {
-    [K in keyof T]: T[K] | MotionValue<T[K]>
+    [K in keyof T]: MotionValueHelper<T[K]>
 }
 
-export type MakeMotion<T> = MakeCustomValueType<MakeMotionHelper<T>>
+type MakeCustomValueTypeHelper<T> = MakeMotionHelper<T>
+export type MakeMotion<T> = MakeCustomValueTypeHelper<T>
 
 export type MotionCSS = MakeMotion<
     Omit<CSSProperties, "rotate" | "scale" | "perspective">
@@ -91,17 +94,18 @@ export type MotionCSS = MakeMotion<
  */
 export type MotionTransform = MakeMotion<TransformProperties>
 
+type MotionCSSVariablesHelper = MotionValueNumber | MotionValueString | stringOrNumber
+
 /**
  * TODO: Currently unused, would like to reimplement with the ability
  * to still accept React.CSSProperties.
  */
 export interface MotionCSSVariables {
-    [key: `--${string}`]:
-        | MotionValueNumber
-        | MotionValueString
-        | string
-        | number
+    [key: `--${string}`]: MotionCSSVariablesHelper
 }
+
+type CustomStylesValueType = MakeCustomValueType<CustomStyles>
+type MotionSVGProps = MakeMotion<SVGPathProperties>
 
 /**
  * @public
@@ -109,8 +113,8 @@ export interface MotionCSSVariables {
 export interface MotionStyle
     extends MotionCSS,
         MotionTransform,
-        MakeMotion<SVGPathProperties>,
-        MakeCustomValueType<CustomStyles> {}
+        MotionSVGProps,
+        CustomStylesValueType {}
 
 export type OnUpdate = (v: Target) => void
 
@@ -265,8 +269,10 @@ export interface MotionAdvancedProps {
     ignoreStrict?: boolean
 }
 
+type MotionStringOrNumber = MotionValueNumber | MotionValueString
+
 interface ExternalMotionValues {
-    [key: string]: MotionValueNumber | MotionValueString
+    [key: string]: MotionStringOrNumber
 }
 
 /**
@@ -329,7 +335,7 @@ export interface MotionProps
         generatedTransform: string
     ): string
 
-    children?: React.ReactNode | MotionValue<number> | MotionValue<string>
+    children?: React.ReactNode | MotionStringOrNumber
 
     "data-framer-appear-id"?: string
 }

--- a/packages/framer-motion/src/render/html/types.ts
+++ b/packages/framer-motion/src/render/html/types.ts
@@ -35,12 +35,16 @@ export interface HTMLRenderState {
     vars: ResolvedValues
 }
 
+type PropsWithRefAttributes<T, P> = PropsWithoutRef<P> & RefAttributes<T>
+interface ReactTypeofSymbol {
+    readonly $$typeof: symbol
+}
+type ForwardRefFn<T, P> = (props: PropsWithRefAttributes<T, P>) => JSX.Element
+
 /**
  * @public
  */
-export type ForwardRefComponent<T, P> = { readonly $$typeof: symbol } & ((
-    props: PropsWithoutRef<P> & RefAttributes<T>
-) => JSX.Element)
+export type ForwardRefComponent<T, P> = ForwardRefFn<T, P> & ReactTypeofSymbol
 
 type AttributesWithoutMotionProps<Attributes> = {
     [K in Exclude<keyof Attributes, keyof MotionProps>]?: Attributes[K]

--- a/packages/framer-motion/src/render/types.ts
+++ b/packages/framer-motion/src/render/types.ts
@@ -7,7 +7,7 @@ import { PresenceContextProps } from "../context/PresenceContext"
 import { MotionProps } from "../motion/types"
 import { AnimationDefinition } from "../animation/types"
 
-export type GenericValues = {
+export interface GenericValues {
     [key: string]: string | number
 }
 
@@ -26,7 +26,7 @@ export type ScrapeMotionValuesFromProps = (
 
 export type UseRenderState<RenderState = any> = () => RenderState
 
-export type VisualElementOptions<Instance, RenderState = any> = {
+export interface VisualElementOptions<Instance, RenderState = any> {
     visualState: VisualState<Instance, RenderState>
     parent?: VisualElement<unknown>
     variantParent?: VisualElement<unknown>

--- a/packages/framer-motion/src/types.ts
+++ b/packages/framer-motion/src/types.ts
@@ -43,7 +43,9 @@ export type ValueTarget = SingleTarget | KeyframesTarget
 /**
  * @public
  */
-export type Props = { [key: string]: any }
+export interface Props {
+    [key: string]: any
+}
 
 /**
  * Options for orchestrating the timing of animations.
@@ -950,7 +952,7 @@ export type PopmotionTransitionProps = Tween | Spring | Keyframes | Inertia
 /**
  * @public
  */
-export type PermissiveTransitionDefinition = {
+export interface PermissiveTransitionDefinition {
     [key: string]: any
 }
 
@@ -970,14 +972,16 @@ export type TransitionMap = Orchestration &
         [key: string]: TransitionDefinition
     }
 
+interface TransitionTypeStaticallyKnown extends Orchestration, Repeat {}
+
 /**
  * Transition props
  *
  * @public
  */
 export type Transition =
-    | (Orchestration & Repeat & TransitionDefinition)
-    | (Orchestration & Repeat & TransitionMap)
+    | (TransitionTypeStaticallyKnown & TransitionDefinition)
+    | (TransitionTypeStaticallyKnown & TransitionMap)
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type CSSPropertiesWithoutTransitionOrSingleTransforms = Omit<
@@ -985,7 +989,7 @@ type CSSPropertiesWithoutTransitionOrSingleTransforms = Omit<
     "transition" | "rotate" | "scale" | "perspective"
 >
 
-type SVGTransformAttributes = {
+interface SVGTransformAttributes {
     attrX?: number
     attrY?: number
     attrScale?: number
@@ -1002,7 +1006,9 @@ type TargetProperties = CSSPropertiesWithoutTransitionOrSingleTransforms &
 /**
  * @public
  */
-export type MakeCustomValueType<T> = { [K in keyof T]: T[K] | CustomValueType }
+export type MakeCustomValueType<T> = {
+    [K in keyof T]: T[K] | CustomValueType
+}
 
 /**
  * @public
@@ -1060,7 +1066,7 @@ export type Variant = TargetAndTransition | TargetResolver
 /**
  * @public
  */
-export type Variants = {
+export interface Variants {
     [key: string]: Variant
 }
 

--- a/packages/framer-motion/src/types.ts
+++ b/packages/framer-motion/src/types.ts
@@ -9,24 +9,30 @@ import { VariableKeyframesDefinition } from "./animation/types"
 
 export type GenericKeyframesTarget<V> = V[] | Array<null | V>
 
+export type stringOrNumber = string | number
+type GenericKeyframesTargetNumber = GenericKeyframesTarget<number>
+type GenericKeyframesTargetString = GenericKeyframesTarget<string>
+
 /**
  * @public
  */
 export type ResolvedKeyframesTarget =
-    | GenericKeyframesTarget<number>
-    | GenericKeyframesTarget<string>
+    | GenericKeyframesTargetNumber
+    | GenericKeyframesTargetString
+
+type KeyframesTargetCustomValueType = GenericKeyframesTarget<CustomValueType>
 
 /**
  * @public
  */
 export type KeyframesTarget =
     | ResolvedKeyframesTarget
-    | GenericKeyframesTarget<CustomValueType>
+    | KeyframesTargetCustomValueType
 
 /**
  * @public
  */
-export type ResolvedSingleTarget = string | number
+export type ResolvedSingleTarget = stringOrNumber
 /**
  * @public
  */
@@ -396,12 +402,12 @@ export interface Tween extends Repeat {
      *
      * @public
      */
-    from?: number | string
+    from?: stringOrNumber
 
     /**
      * @internal
      */
-    to?: number | string | ValueTarget
+    to?: stringOrNumber | ValueTarget
 
     /**
      * @internal
@@ -583,12 +589,12 @@ export interface Spring extends Repeat {
      *
      * @public
      */
-    from?: number | string
+    from?: stringOrNumber
 
     /**
      * @internal
      */
-    to?: number | string | ValueTarget
+    to?: stringOrNumber | ValueTarget
 
     /**
      * The initial velocity of the spring. By default this is the current velocity of the component.
@@ -785,7 +791,7 @@ export interface Inertia {
      *
      * @public
      */
-    from?: number | string
+    from?: stringOrNumber
 
     /**
      * The initial velocity of the animation.
@@ -899,12 +905,12 @@ export interface Keyframes {
     /**
      * @internal
      */
-    from?: number | string
+    from?: stringOrNumber
 
     /**
      * @internal
      */
-    to?: number | string | ValueTarget
+    to?: stringOrNumber | ValueTarget
 
     /**
      * @internal
@@ -931,7 +937,7 @@ export interface None {
     /**
      * @internal
      */
-    from?: number | string
+    from?: stringOrNumber
 
     /**
      * @internal
@@ -995,19 +1001,23 @@ interface SVGTransformAttributes {
     attrScale?: number
 }
 
+type SVGElementAttributes = SVGAttributes<SVGElement>
+
 type TargetProperties = CSSPropertiesWithoutTransitionOrSingleTransforms &
-    SVGAttributes<SVGElement> &
+    SVGElementAttributes &
     SVGTransformAttributes &
     TransformProperties &
     CustomStyles &
     SVGPathProperties &
     VariableKeyframesDefinition
 
+type MakeCustomValueTypeHelper<T> = T | CustomValueType
+
 /**
  * @public
  */
 export type MakeCustomValueType<T> = {
-    [K in keyof T]: T[K] | CustomValueType
+    [K in keyof T]: MakeCustomValueTypeHelper<T[K]>
 }
 
 /**
@@ -1015,11 +1025,13 @@ export type MakeCustomValueType<T> = {
  */
 export type Target = MakeCustomValueType<TargetProperties>
 
+type MakeKeyframesHelper<T> = T | T[] | [null, ...T[]]
+
 /**
  * @public
  */
 export type MakeKeyframes<T> = {
-    [K in keyof T]: T[K] | T[K][] | [null, ...T[K][]]
+    [K in keyof T]: MakeKeyframesHelper<T[K]>
 }
 
 /**
@@ -1047,7 +1059,7 @@ export type TargetWithKeyframes = MakeKeyframes<Target>
  *
  * @public
  */
-export type TargetAndTransition = TargetWithKeyframes & {
+export interface TargetAndTransition extends TargetWithKeyframes {
     transition?: Transition
     transitionEnd?: Target
 }
@@ -1074,6 +1086,6 @@ export interface Variants {
  * @public
  */
 export interface CustomValueType {
-    mix: (from: any, to: any) => (p: number) => number | string
-    toValue: () => number | string
+    mix: (from: any, to: any) => (p: number) => stringOrNumber
+    toValue: () => stringOrNumber
 }


### PR DESCRIPTION
- interface is faster than type for intersection
- creating smaller types/interfaces leverages TSC's caching, so it doesn't need to re-calc 
- explicit-module-boundary-types would allow for faster d.ts emits in the future