### PR TITLE
`AnimatePresence` `propagate` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [11.17.0] Unreleased
+
+### Added
+
+-   Added `propagate` to `AnimatePresence`. This prop allows parent exit animations to be propagated to children.
+
+### Removed
+
+-   Removed `exitBeforeEnter` from `AnimatePresence`.
+
 ## [11.16.7] 2024-01-10
 
 ### Fixed

--- a/dev/react/src/examples/AnimatePresence.tsx
+++ b/dev/react/src/examples/AnimatePresence.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence } from "framer-motion"
+import { AnimatePresence, motion } from "framer-motion"
 import { useState } from "react"
 
 /**
@@ -16,7 +16,10 @@ export const App = () => {
     const [isVisible, setVisible] = useState(true)
 
     return (
-        <div onClick={() => setVisible(!isVisible)}>
+        <div
+            onClick={() => setVisible(!isVisible)}
+            style={{ width: 1000, height: 1000, background: "green" }}
+        >
             <AnimatePresence
                 initial={false}
                 onExitComplete={() => console.log("rest")}
@@ -29,7 +32,22 @@ export const App = () => {
                         exit={{ opacity: 0 }}
                         transition={{ duration: 1 }}
                         style={style}
-                    />
+                    >
+                        <AnimatePresence propagate initial={false}>
+                            <motion.div
+                                key="b"
+                                exit={{ x: 100 }}
+                                transition={{ duration: 1 }}
+                                style={{
+                                    width: 50,
+                                    height: 50,
+                                    background: "blue",
+                                }}
+                            >
+                                Hello
+                            </motion.div>
+                        </AnimatePresence>
+                    </motion.div>
                 )}
             </AnimatePresence>
         </div>

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { useContext, useState, useMemo, useRef } from "react"
 import * as React from "react"
-import { AnimatePresenceProps } from "./types"
-import { PresenceChild } from "./PresenceChild"
+import { useContext, useMemo, useRef, useState } from "react"
 import { LayoutGroupContext } from "../../context/LayoutGroupContext"
-import { invariant } from "motion-utils"
 import { useIsomorphicLayoutEffect } from "../../three-entry"
 import { useConstant } from "../../utils/use-constant"
+import { PresenceChild } from "./PresenceChild"
+import { AnimatePresenceProps } from "./types"
+import { usePresence } from "./use-presence"
 import { ComponentKey, getChildKey, onlyElements } from "./utils"
 
 /**
@@ -47,14 +47,14 @@ export const AnimatePresence: React.FunctionComponent<
     React.PropsWithChildren<AnimatePresenceProps>
 > = ({
     children,
-    exitBeforeEnter,
     custom,
     initial = true,
     onExitComplete,
     presenceAffectsLayout = true,
     mode = "sync",
+    propagate,
 }) => {
-    invariant(!exitBeforeEnter, "Replace exitBeforeEnter with mode='wait'")
+    const [isParentPresent, safeToRemove] = usePresence()
 
     /**
      * Filter any children that aren't ReactElements. We can only track components
@@ -66,7 +66,8 @@ export const AnimatePresence: React.FunctionComponent<
      * Track the keys of the currently rendered children. This is used to
      * determine which children are exiting.
      */
-    const presentKeys = presentChildren.map(getChildKey)
+    const presentKeys =
+        propagate && !isParentPresent ? [] : presentChildren.map(getChildKey)
 
     /**
      * If `initial={false}` we only want to pass this to components in the first render.
@@ -172,8 +173,10 @@ export const AnimatePresence: React.FunctionComponent<
                 const key = getChildKey(child)
 
                 const isPresent =
-                    presentChildren === renderedChildren ||
-                    presentKeys.includes(key)
+                    propagate && !isParentPresent
+                        ? false
+                        : presentChildren === renderedChildren ||
+                          presentKeys.includes(key)
 
                 const onExit = () => {
                     if (exitComplete.has(key)) {
@@ -190,6 +193,8 @@ export const AnimatePresence: React.FunctionComponent<
                     if (isEveryExitComplete) {
                         forceRender?.()
                         setRenderedChildren(pendingPresentChildren.current)
+
+                        propagate && safeToRemove?.()
 
                         onExitComplete && onExitComplete()
                     }

--- a/packages/framer-motion/src/components/AnimatePresence/types.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/types.ts
@@ -40,15 +40,6 @@ export interface AnimatePresenceProps {
     onExitComplete?: () => void
 
     /**
-     * Replace with `mode="wait"`
-     *
-     * @deprecated
-     *
-     * Replace with `mode="wait"`
-     */
-    exitBeforeEnter?: boolean
-
-    /**
      * Determines how to handle entering and exiting elements.
      *
      * - `"sync"`: Default. Elements animate in and out as soon as they're added/removed.
@@ -66,4 +57,10 @@ export interface AnimatePresenceProps {
      * child being removed.
      */
     presenceAffectsLayout?: boolean
+
+    /**
+     * If true, the `AnimatePresence` component will propagate parent exit animations
+     * to its children.
+     */
+    propagate?: boolean
 }


### PR DESCRIPTION
This PR adds a `propagate` option to `AnimatePresence`.

Usually, `AnimatePresence` components are solely in control of the presence of their own children. Nested `AnimatePresence` components essentially act as a barrier.

```jsx
<AnimatePresence>
  {show ? (
    <motion.div exit={{ opacity: 0 }}>
      <AnimatePresence>
        <motion.div exit={{ x: 100 }} /> // This won't fire
      </AnimatePresence>
    </motion.div>
  ) : null}
</AnimatePresence>
```

This often makes sense, for example you might have a sidebar of items. The items might be removable and you want them to have their own exit animations. The sidebar might be removable and have its own exit animations - you wouldn't want the items to fire their exit animations when the sidebar is removed.

With `propagate` enabled, children will fire exit animations both when they're removed from their own `AnimatePresence` but also now when their ancestor `AnimatePresence` is removed. This works on infinitely deep trees, but `propagate={false}` will break this chain.

```jsx
<AnimatePresence>
  {show ? (
    <motion.div exit={{ opacity: 0 }}>
      <AnimatePresence propagate>
        <motion.div exit={{ x: 100 }} /> // This will fire when show is false
      </AnimatePresence>
    </motion.div>
  ) : null}
</AnimatePresence>
```

resolves https://github.com/motiondivision/motion/issues/746