### PR TITLE
Add missing types for framer-motion

### DIFF
--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -10,7 +10,7 @@ export { MotionConfig } from "./components/MotionConfig"
 export { Reorder } from "./components/Reorder"
 export { m } from "./render/components/m/proxy"
 export { motion } from "./render/components/motion/proxy"
-
+export * from "./animation/types"
 export * from "./dom"
 export * from "./three-entry"
 


### PR DESCRIPTION
All the members of `framer-motion/src/animation/types.ts` are not available anymore. This makes sure we export it at the top level.