### PR TITLE
Adding `element` as first argument to gesture start callbacks 

### DIFF
--- a/dev/html/public/playwright/gestures/hover.html
+++ b/dev/html/public/playwright/gestures/hover.html
@@ -20,7 +20,7 @@
         <script type="module">
             const { hover } = window.MotionDOM
 
-            hover("#hover", ({ target }) => {
+            hover("#hover", (target) => {
                 target.innerHTML = "start"
 
                 return () => {
@@ -29,7 +29,7 @@
             })
 
             let multiCount = 0
-            hover("#multi", ({ target }) => {
+            hover("#multi", (target) => {
                 target.innerHTML = multiCount
                 multiCount++
 
@@ -42,7 +42,7 @@
             let onceCount = 0
             hover(
                 "#once",
-                ({ target }) => {
+                (target) => {
                     target.innerHTML = onceCount
                     onceCount++
 

--- a/dev/html/public/playwright/gestures/press.html
+++ b/dev/html/public/playwright/gestures/press.html
@@ -28,7 +28,7 @@
         <script type="module">
             const { press } = window.MotionDOM
 
-            press("#press-div", ({ target }, info, originalEvent) => {
+            press("#press-div", (target) => {
                 console.log("pointer down")
                 target.innerHTML = "start"
 
@@ -38,12 +38,10 @@
                 }
             })
 
-            press("#press-div-cancel", ({ target }, info) => {
-                console.log(target, info)
+            press("#press-div-cancel", (target) => {
                 target.innerHTML = "start"
 
                 return (event, { success }) => {
-                    console.log(event, success)
                     target.innerHTML = success ? "end" : "cancel"
                 }
             })

--- a/packages/framer-motion/src/dom.ts
+++ b/packages/framer-motion/src/dom.ts
@@ -1,7 +1,8 @@
-export { isDragActive } from "motion-dom"
+export { hover, isDragActive, press } from "motion-dom"
 export { invariant, noop, progress } from "motion-utils"
 
 export type * from "motion-dom"
+
 export { animate, createScopedAnimate } from "./animation/animate"
 export { animateMini } from "./animation/animators/waapi/animate-style"
 export { scroll } from "./render/dom/scroll"

--- a/packages/framer-motion/src/gestures/hover.ts
+++ b/packages/framer-motion/src/gestures/hover.ts
@@ -1,8 +1,8 @@
-import type { VisualElement } from "../render/VisualElement"
-import { Feature } from "../motion/features/Feature"
-import { frame } from "../frameloop"
 import { hover } from "motion-dom"
 import { extractEventInfo } from "../events/event-info"
+import { frame } from "../frameloop"
+import { Feature } from "../motion/features/Feature"
+import type { VisualElement } from "../render/VisualElement"
 
 function handleHoverEvent(
     node: VisualElement<Element>,
@@ -27,7 +27,7 @@ export class HoverGesture extends Feature<Element> {
         const { current } = this.node
         if (!current) return
 
-        this.unmount = hover(current, (startEvent) => {
+        this.unmount = hover(current, (_element, startEvent) => {
             handleHoverEvent(this.node, startEvent, "Start")
 
             return (endEvent) => handleHoverEvent(this.node, endEvent, "End")

--- a/packages/framer-motion/src/gestures/press.ts
+++ b/packages/framer-motion/src/gestures/press.ts
@@ -1,8 +1,8 @@
-import { Feature } from "../motion/features/Feature"
 import { press } from "motion-dom"
-import { VisualElement } from "../render/VisualElement"
-import { frame } from "../frameloop"
 import { extractEventInfo } from "../events/event-info"
+import { frame } from "../frameloop"
+import { Feature } from "../motion/features/Feature"
+import { VisualElement } from "../render/VisualElement"
 
 function handlePressEvent(
     node: VisualElement<Element>,
@@ -33,7 +33,7 @@ export class PressGesture extends Feature<Element> {
 
         this.unmount = press(
             current,
-            (startEvent) => {
+            (_element, startEvent) => {
                 handlePressEvent(this.node, startEvent, "Start")
 
                 return (endEvent, { success }) =>

--- a/packages/framer-motion/src/render/dom/viewport/index.ts
+++ b/packages/framer-motion/src/render/dom/viewport/index.ts
@@ -22,7 +22,10 @@ const thresholds = {
 
 export function inView(
     elementOrSelector: ElementOrSelector,
-    onStart: (entry: IntersectionObserverEntry) => void | ViewChangeHandler,
+    onStart: (
+        element: Element,
+        entry: IntersectionObserverEntry
+    ) => void | ViewChangeHandler,
     { root, margin: rootMargin, amount = "some" }: InViewOptions = {}
 ): VoidFunction {
     const elements = resolveElements(elementOrSelector)
@@ -40,7 +43,7 @@ export function inView(
             if (entry.isIntersecting === Boolean(onEnd)) return
 
             if (entry.isIntersecting) {
-                const newOnEnd = onStart(entry)
+                const newOnEnd = onStart(entry.target, entry)
                 if (typeof newOnEnd === "function") {
                     activeIntersections.set(entry.target, newOnEnd)
                 } else {

--- a/packages/motion-dom/src/gestures/hover.ts
+++ b/packages/motion-dom/src/gestures/hover.ts
@@ -11,7 +11,10 @@ import { setupGesture } from "./utils/setup"
  *
  * @public
  */
-export type OnHoverStartEvent = (event: PointerEvent) => void | OnHoverEndEvent
+export type OnHoverStartEvent = (
+    element: Element,
+    event: PointerEvent
+) => void | OnHoverEndEvent
 
 /**
  * A function to be called when a hover gesture ends.
@@ -20,15 +23,8 @@ export type OnHoverStartEvent = (event: PointerEvent) => void | OnHoverEndEvent
  */
 export type OnHoverEndEvent = (event: PointerEvent) => void
 
-/**
- * Filter out events that are not pointer events, or are triggering
- * while a Motion gesture is active.
- */
-function filterEvents(callback: OnHoverStartEvent) {
-    return (event: PointerEvent) => {
-        if (event.pointerType === "touch" || isDragActive()) return
-        callback(event)
-    }
+function isValidHover(event: PointerEvent) {
+    return !(event.pointerType === "touch" || isDragActive())
 }
 
 /**
@@ -48,26 +44,30 @@ export function hover(
         options
     )
 
-    const onPointerEnter = filterEvents((enterEvent: PointerEvent) => {
+    const onPointerEnter = (enterEvent: PointerEvent) => {
+        if (!isValidHover(enterEvent)) return
+
         const { target } = enterEvent
-        const onHoverEnd = onHoverStart(enterEvent)
+        const onHoverEnd = onHoverStart(target as Element, enterEvent)
 
         if (typeof onHoverEnd !== "function" || !target) return
 
-        const onPointerLeave = filterEvents((leaveEvent: PointerEvent) => {
+        const onPointerLeave = (leaveEvent: PointerEvent) => {
+            if (!isValidHover(leaveEvent)) return
+
             onHoverEnd(leaveEvent)
             target.removeEventListener(
                 "pointerleave",
                 onPointerLeave as EventListener
             )
-        })
+        }
 
         target.addEventListener(
             "pointerleave",
             onPointerLeave as EventListener,
             eventOptions
         )
-    })
+    }
 
     elements.forEach((element) => {
         element.addEventListener(

--- a/packages/motion-dom/src/gestures/press/index.ts
+++ b/packages/motion-dom/src/gestures/press/index.ts
@@ -57,7 +57,7 @@ export function press(
 
         isPressing.add(element)
 
-        const onPressEnd = onPressStart(startEvent)
+        const onPressEnd = onPressStart(element, startEvent)
 
         const onPointerEnd = (endEvent: PointerEvent, success: boolean) => {
             window.removeEventListener("pointerup", onPointerUp)

--- a/packages/motion-dom/src/gestures/press/types.ts
+++ b/packages/motion-dom/src/gestures/press/types.ts
@@ -7,4 +7,7 @@ export type OnPressEndEvent = (
     info: PressGestureInfo
 ) => void
 
-export type OnPressStartEvent = (event: PointerEvent) => OnPressEndEvent | void
+export type OnPressStartEvent = (
+    element: Element,
+    event: PointerEvent
+) => OnPressEndEvent | void


### PR DESCRIPTION
This PR changes `press`, `hover` and `inView` callbacks to accept `element` as the initial argument.

```javascript
hover("a", (element, startEvent) => {
  return (endEvent) => {}
})
```