### PR TITLE
Prevent starting new layout animation when target hasn't changed

### DIFF
--- a/dev/react/src/tests/layout-rerender.tsx
+++ b/dev/react/src/tests/layout-rerender.tsx
@@ -1,0 +1,63 @@
+import { motion, useMotionValue } from "framer-motion"
+import { useEffect, useState } from "react"
+
+export const App = () => {
+    const params = new URLSearchParams(window.location.search)
+    const parent = params.get("parent") || false
+    const [state, setState] = useState(0)
+    const backgroundColor = useMotionValue("red")
+    const renderCount = useMotionValue(0)
+
+    useEffect(() => {
+        if (state === 1) {
+            setTimeout(() => setState(2), 50)
+        }
+    }, [state])
+
+    return (
+        <>
+            <button onClick={() => setState(state + 1)}>Update</button>
+            <motion.pre id="render-count">{renderCount}</motion.pre>
+            <motion.div
+                layout={Boolean(parent)}
+                style={{
+                    position: "relative",
+                    width: 500,
+                    height: state ? 500 : 400,
+                }}
+            >
+                <motion.div
+                    id="box"
+                    data-testid="box"
+                    layout
+                    style={{ ...(state ? a : b), backgroundColor }}
+                    transition={{ duration: 1 }}
+                    onLayoutAnimationStart={() =>
+                        renderCount.set(renderCount.get() + 1)
+                    }
+                />
+            </motion.div>
+        </>
+    )
+}
+
+const box = {
+    position: "absolute",
+    top: 100,
+    left: 100,
+    background: "red",
+}
+
+const a = {
+    ...box,
+    width: 100,
+    height: 200,
+}
+
+const b = {
+    ...box,
+    top: 100,
+    left: 200,
+    width: 300,
+    height: 300,
+}

--- a/packages/framer-motion/cypress/integration/layout.ts
+++ b/packages/framer-motion/cypress/integration/layout.ts
@@ -300,4 +300,28 @@ describe("Layout animation", () => {
                 })
             })
     })
+
+    it("A new layout animation isn't started if the target doesn't change", () => {
+        cy.visit("?test=layout-rerender")
+            .wait(50)
+            .get("button")
+            .trigger("click")
+            .wait(200)
+            .get("#render-count")
+            .should(([$count]: any) => {
+                expect($count.textContent).to.equal("1")
+            })
+    })
+
+    it("A new layout animation isn't started if the target doesn't change, even if parent starts layout animation", () => {
+        cy.visit("?test=layout-rerender&parent=true")
+            .wait(50)
+            .get("button")
+            .trigger("click")
+            .wait(200)
+            .get("#render-count")
+            .should(([$count]: any) => {
+                expect($count.textContent).to.equal("1")
+            })
+    })
 })

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -143,7 +143,7 @@ export interface LayoutUpdateData {
     delta: Delta
     layoutDelta: Delta
     hasLayoutChanged: boolean
-    hasRelativeTargetChanged: boolean
+    hasRelativeLayoutChanged: boolean
 }
 
 export type LayoutUpdateHandler = (data: LayoutUpdateData) => void


### PR DESCRIPTION
When we're performing a layout animation, we don't want to start a new layout animation unless the target/origin has changed. 

This is already the default behaviour but the included test shows that when a parent is also performing an animation then a new animation always starts, pointing to a check needed with relative animations.

Fixes https://github.com/motiondivision/motion/issues/1085