### PR TITLE
Fixing custom `children` type

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -146,7 +146,7 @@ export const AnimatePresence = ({
          * Early return to ensure once we've set state with the latest diffed
          * children, we can immediately re-render.
          */
-        return
+        return null
     }
 
     if (

--- a/packages/framer-motion/src/motion/__tests__/custom.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/custom.test.tsx
@@ -1,7 +1,7 @@
-import { render } from "../../../jest.setup"
-import { motion, useMotionValue } from "../.."
 import * as React from "react"
 import { ForwardedRef } from "react"
+import { motion, useMotionValue } from "../.."
+import { render } from "../../../jest.setup"
 import { MotionProps } from "../types"
 
 interface Props {
@@ -102,6 +102,39 @@ function runTests(name: string, motionFactory: typeof motion.create) {
             render(<Component />)
 
             expect(children!).toEqual(5)
+        })
+
+        test("Accepts children as a function if original component accepts children as a function", () => {
+            const BaseComponent = React.forwardRef(
+                (
+                    props: Props & {
+                        children:
+                            | React.ReactNode
+                            | (({
+                                  isServer,
+                              }: {
+                                  isServer: boolean
+                              }) => React.ReactNode)
+                    },
+                    ref: ForwardedRef<HTMLDivElement>
+                ) => {
+                    return (
+                        <div ref={ref}>
+                            {typeof props.children === "function"
+                                ? props.children({ isServer: false })
+                                : props.children}
+                        </div>
+                    )
+                }
+            )
+
+            const MotionComponent = motionFactory(BaseComponent)
+
+            const Component = () => (
+                <MotionComponent foo>{() => <div />}</MotionComponent>
+            )
+
+            render(<Component />)
         })
     })
 }

--- a/packages/framer-motion/src/render/components/create-factory.ts
+++ b/packages/framer-motion/src/render/components/create-factory.ts
@@ -2,17 +2,23 @@ import {
     createRendererMotionComponent,
     MotionComponentProps,
 } from "../../motion"
-import { DOMMotionComponents } from "../dom/types"
-import { CreateVisualElement } from "../types"
 import { FeaturePackages } from "../../motion/features/types"
-import { isSVGComponent } from "../dom/utils/is-svg-component"
-import { svgMotionConfig } from "../svg/config-motion"
-import { htmlMotionConfig } from "../html/config-motion"
+import { DOMMotionComponents } from "../dom/types"
 import { createUseRender } from "../dom/use-render"
+import { isSVGComponent } from "../dom/utils/is-svg-component"
+import { htmlMotionConfig } from "../html/config-motion"
+import { svgMotionConfig } from "../svg/config-motion"
+import { CreateVisualElement } from "../types"
 
 type MotionComponent<T, P> = T extends keyof DOMMotionComponents
     ? DOMMotionComponents[T]
-    : React.ComponentType<MotionComponentProps<React.PropsWithChildren<P>>>
+    : React.ComponentType<
+          Omit<MotionComponentProps<P>, "children"> & {
+              children?: P extends { children: infer C }
+                  ? C | MotionComponentProps<P>["children"]
+                  : MotionComponentProps<P>["children"]
+          }
+      >
 
 export function createMotionComponentFactory(
     preloadedFeatures?: FeaturePackages,


### PR DESCRIPTION
This PR fixes the typing of `children` for both `motion` and `AnimatePresence`.

`motion` components will now accept any `children` that the component passed to it via `motion.create` accepts.

`AnimatePresence` will stop throwing type errors in React 18