### PR TITLE
Deprecate Motion 3D

### DIFF
--- a/packages/framer-motion-3d/src/components/LayoutCamera.tsx
+++ b/packages/framer-motion-3d/src/components/LayoutCamera.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { forwardRef, JSX } from "react"
-import { PerspectiveCamera as PerspectiveCameraImpl } from "three"
-import { mergeRefs } from "react-merge-refs"
-import { LayoutCameraProps } from "./types"
-import { motion } from "../render/motion"
-import { useLayoutCamera } from "./use-layout-camera"
-import { ThreeMotionProps } from "../types"
 import { extend } from "@react-three/fiber"
+import { forwardRef, JSX } from "react"
+import { mergeRefs } from "react-merge-refs"
+import { PerspectiveCamera as PerspectiveCameraImpl } from "three"
+import { motion } from "../render/motion"
+import { ThreeMotionProps } from "../types"
+import { LayoutCameraProps } from "./types"
+import { useLayoutCamera } from "./use-layout-camera"
 
 extend({ PerspectiveCamera: PerspectiveCameraImpl })
 
@@ -17,6 +17,8 @@ type Props = JSX.IntrinsicElements["perspectiveCamera"] &
 
 /**
  * Adapted from https://github.com/pmndrs/drei/blob/master/src/core/PerspectiveCamera.tsx
+ *
+ * @deprecated Motion 3D is deprecated.
  */
 export const LayoutCamera = forwardRef((props: Props, ref) => {
     const { cameraRef } = useLayoutCamera<PerspectiveCameraImpl>(

--- a/packages/framer-motion-3d/src/components/LayoutOrthographicCamera.tsx
+++ b/packages/framer-motion-3d/src/components/LayoutOrthographicCamera.tsx
@@ -1,13 +1,13 @@
 "use client"
 
+import { extend } from "@react-three/fiber"
 import { forwardRef, JSX } from "react"
-import { OrthographicCamera as OrthographicCameraImpl } from "three"
 import { mergeRefs } from "react-merge-refs"
+import { OrthographicCamera as OrthographicCameraImpl } from "three"
 import { motion } from "../render/motion"
+import { ThreeMotionProps } from "../types"
 import { LayoutCameraProps } from "./types"
 import { useLayoutCamera } from "./use-layout-camera"
-import { ThreeMotionProps } from "../types"
-import { extend } from "@react-three/fiber"
 
 extend({ OrthographicCamera: OrthographicCameraImpl })
 
@@ -15,6 +15,9 @@ type Props = JSX.IntrinsicElements["orthographicCamera"] &
     LayoutCameraProps &
     ThreeMotionProps
 
+/**
+ * @deprecated Motion 3D is deprecated.
+ */
 export const LayoutOrthographicCamera = forwardRef((props: Props, ref) => {
     const { size, cameraRef } = useLayoutCamera<OrthographicCameraImpl>(
         props,

--- a/packages/framer-motion-3d/src/components/MotionCanvas.tsx
+++ b/packages/framer-motion-3d/src/components/MotionCanvas.tsx
@@ -1,30 +1,30 @@
 "use client"
 
-import * as React from "react"
 import {
-    useContext,
-    useLayoutEffect,
-    useRef,
-    forwardRef,
-    MutableRefObject,
-} from "react"
+    Camera,
+    events as createPointerEvents,
+    createRoot,
+    Dpr,
+    Props,
+    ReconcilerRoot,
+    unmountComponentAtNode,
+} from "@react-three/fiber"
 import {
     clamp,
-    MotionContext,
     MotionConfigContext,
+    MotionContext,
     useForceUpdate,
     useIsomorphicLayoutEffect,
 } from "framer-motion"
-import { mergeRefs } from "react-merge-refs"
+import * as React from "react"
 import {
-    createRoot,
-    unmountComponentAtNode,
-    events as createPointerEvents,
-    Props,
-    Camera,
-    Dpr,
-    ReconcilerRoot,
-} from "@react-three/fiber"
+    forwardRef,
+    MutableRefObject,
+    useContext,
+    useLayoutEffect,
+    useRef,
+} from "react"
+import { mergeRefs } from "react-merge-refs"
 import { DimensionsState, MotionCanvasContext } from "./MotionCanvasContext"
 
 export interface MotionCanvasProps extends Omit<Props, "resize"> {}
@@ -187,4 +187,7 @@ function CanvasComponent(
     )
 }
 
+/**
+ * @deprecated Motion 3D is deprecated.
+ */
 export const MotionCanvas = forwardRef(CanvasComponent)

--- a/packages/framer-motion-3d/src/render/motion.ts
+++ b/packages/framer-motion-3d/src/render/motion.ts
@@ -1,14 +1,14 @@
 "use client"
 
 import {
+    animations,
     createRendererMotionComponent,
     FeatureBundle,
-    animations,
     makeUseVisualState,
 } from "framer-motion"
+import type { ThreeMotionComponents, ThreeRenderState } from "../types"
+import { createRenderState, createVisualElement } from "./create-visual-element"
 import { useRender } from "./use-render"
-import type { ThreeRenderState, ThreeMotionComponents } from "../types"
-import { createVisualElement, createRenderState } from "./create-visual-element"
 import { scrapeMotionValuesFromProps } from "./utils/scrape-motion-value"
 
 const useVisualState = makeUseVisualState({
@@ -31,6 +31,10 @@ function custom<Props extends {}>(Component: string) {
 }
 
 const componentCache = new Map<string, any>()
+
+/**
+ * @deprecated Motion 3D is deprecated.
+ */
 export const motion = new Proxy(custom, {
     get: (_, key: string) => {
         !componentCache.has(key) && componentCache.set(key, custom(key))

--- a/packages/framer-motion-3d/src/utils/use-time.ts
+++ b/packages/framer-motion-3d/src/utils/use-time.ts
@@ -2,6 +2,9 @@ import { useFrame } from "@react-three/fiber"
 import { MotionConfigContext, useMotionValue } from "framer-motion"
 import { useContext } from "react"
 
+/**
+ * @deprecated Motion 3D is deprecated.
+ */
 export function useTime() {
     const time = useMotionValue(0)
     const { isStatic } = useContext(MotionConfigContext)


### PR DESCRIPTION
This PR deprecates Motion 3D. The usage/maintenance ratio isn't sustainable at this point, and it hasn't been kept in the state I'd prefer. 

Although not directly comparable from a DX point of view, Motion can be used to animate Three.js directly. https://examples.motion.dev/js/three

Closes https://github.com/motiondivision/motion/issues/3040
Closes https://github.com/motiondivision/motion/issues/2790
Closes https://github.com/motiondivision/motion/issues/2644
Closes https://github.com/motiondivision/motion/issues/2621
Closes https://github.com/motiondivision/motion/issues/2159
Closes https://github.com/motiondivision/motion/issues/2144
Closes https://github.com/motiondivision/motion/issues/1444