### PR TITLE
fix: fix to ignore press event when button is disabled

### DIFF
--- a/packages/framer-motion/src/gestures/__tests__/press.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/press.test.tsx
@@ -721,4 +721,19 @@ describe("press", () => {
             0.5, 0.75, 1, 1, 1, 1, 1, 1, 1,
         ])
     })
+
+    test("ignore press event when button is disabled", async () => {
+        const press = jest.fn()
+        const Component = () => <motion.button onTap={() => press()} disabled />
+
+        const { container, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        pointerDown(container.firstChild as Element)
+        pointerUp(container.firstChild as Element)
+
+        await nextFrame()
+
+        expect(press).toBeCalledTimes(0)
+    })
 })

--- a/packages/framer-motion/src/gestures/press.ts
+++ b/packages/framer-motion/src/gestures/press.ts
@@ -11,6 +11,10 @@ function handlePressEvent(
 ) {
     const { props } = node
 
+    if (node.current instanceof HTMLButtonElement && node.current.disabled) {
+        return
+    }
+
     if (node.animationState && props.whileTap) {
         node.animationState.setActive("whileTap", lifecycle === "Start")
     }


### PR DESCRIPTION
#3055

Now, onTap callback does not fire when button has disabled prop set to true.