### PR TITLE
fix #2822 - Get transform values from DOM as animation starting point

### DIFF
--- a/dev/react/src/examples/Animation-useAnimate-initial-transform.tsx
+++ b/dev/react/src/examples/Animation-useAnimate-initial-transform.tsx
@@ -1,0 +1,34 @@
+import { useAnimate } from "framer-motion"
+
+export const App = () => {
+    const [scope, animate] = useAnimate()
+
+    return (
+        <div className="App" ref={scope}>
+            <div
+                className="four"
+                style={{
+                    width: 50,
+                    height: 50,
+                    opacity: 0.5,
+                    backgroundColor: "hotpink",
+                    transform: "scale(0.1)",
+                }}
+            ></div>
+            <p>Take in original transform</p>
+            <button
+                onClick={() => {
+                    animate([
+                        [
+                            ".four",
+                            { x: 90, scale: 2, opacity: 1 },
+                            { duration: 2 },
+                        ],
+                    ])
+                }}
+            >
+                play
+            </button>
+        </div>
+    )
+}

--- a/packages/framer-motion/src/render/html/HTMLVisualElement.ts
+++ b/packages/framer-motion/src/render/html/HTMLVisualElement.ts
@@ -10,7 +10,7 @@ import type { ResolvedValues } from "../types"
 import { VisualElement } from "../VisualElement"
 import { HTMLRenderState } from "./types"
 import { buildHTMLStyles } from "./utils/build-styles"
-import { transformProps } from "./utils/keys-transform"
+import { getTransformValue, transformProps } from "./utils/keys-transform"
 import { renderHTML } from "./utils/render"
 import { scrapeMotionValuesFromProps } from "./utils/scrape-motion-values"
 
@@ -31,6 +31,15 @@ export class HTMLVisualElement extends DOMVisualElement<
     ): string | number | null | undefined {
         if (transformProps.has(key)) {
             const defaultType = getDefaultValueType(key)
+            const transformValue = getTransformValue(instance, key)
+
+            if (transformValue !== null) {
+                return transformValue
+            }
+
+            // If we could not get a transform value, we return the default value.
+            // This default value might NOT resemble the actual DOM value, resulting in
+            // an animation that has a different starting value than the actual DOM.
             return defaultType ? defaultType.default || 0 : 0
         } else {
             const computedStyle = getComputedStyle(instance)

--- a/packages/framer-motion/src/render/html/utils/keys-transform.ts
+++ b/packages/framer-motion/src/render/html/utils/keys-transform.ts
@@ -25,3 +25,69 @@ export const transformPropOrder = [
  * A quick lookup for transform props.
  */
 export const transformProps = new Set(transformPropOrder)
+
+type TransformValues = Record<
+    (typeof transformPropOrder)[number],
+    number | null
+>
+
+export const getTransformValues = (instance: HTMLElement): TransformValues => {
+    const computedStyle = getComputedStyle(instance)
+    const transform = computedStyle.transform || "none"
+
+    // Default result object
+    const result: TransformValues = Object.fromEntries(
+        transformPropOrder.map((prop) => [prop, null])
+    ) as TransformValues
+
+    // If there's no transform applied, return the default object
+    if (transform === "none") return result
+
+    // Computed style of a transform returns either a 2D or 3D matrix,
+    // we need to handle both cases.
+    const matrix2DMatch = transform.match(/^matrix\(([-\d.e\s,]+)\)$/)
+    const matrix3DMatch = transform.match(/^matrix3d\(([-\d.e\s,]+)\)$/)
+
+    if (matrix2DMatch) {
+        const values = matrix2DMatch[1]
+            .split(",")
+            .map((v) => parseFloat(v.trim()))
+        if (values.length === 6) {
+            result.translateX = values[4]
+            result.translateY = values[5]
+            result.x = result.translateX
+            result.y = result.translateY
+            result.scaleX = values[0]
+            result.scaleY = values[3]
+            result.scale = (Math.abs(values[0]) + Math.abs(values[3])) / 2
+            result.skewX = Math.atan(values[1]) * (180 / Math.PI)
+            result.skewY = Math.atan(values[2]) * (180 / Math.PI)
+            result.skew = (Math.abs(values[1]) + Math.abs(values[2])) / 2
+        }
+    } else if (matrix3DMatch) {
+        const values = matrix3DMatch[1]
+            .split(",")
+            .map((v) => parseFloat(v.trim()))
+        if (values.length === 16) {
+            result.translateX = values[12]
+            result.translateY = values[13]
+            result.translateZ = values[14]
+            result.x = result.translateX
+            result.y = result.translateY
+            result.z = result.translateZ
+            result.scaleX = values[0]
+            result.scaleY = values[5]
+            result.scale = (Math.abs(values[0]) + Math.abs(values[5])) / 2
+            result.rotateX = Math.asin(-values[6]) * (180 / Math.PI)
+            result.rotateY = Math.atan2(values[2], values[10]) * (180 / Math.PI)
+            result.rotateZ = Math.atan2(values[4], values[0]) * (180 / Math.PI)
+        }
+    }
+
+    return result
+}
+
+export const getTransformValue = (instance: HTMLElement, key: string) => {
+    const values = getTransformValues(instance)
+    return values[key as keyof TransformValues]
+}


### PR DESCRIPTION
Fix #2822 

As discussed on Discord, I ran into a similar issue last week. I took some time to dive into the codebase, and might have found a fix for this. I'm not sure if this is the desired behavior though... So open to discuss approaches. 

It adds a util function that gets the transform matrix via computed style, to extract all transform properties from it. It uses this for starting points of animations where the transform property value is `null`. In the previous implementation we  were extracting all styles from the DOM, except for transform styles. This function adds the logic, while keeping the logic for the default values too. 

Also added an example file that demonstrates the behavior. Before this change the scale would start at `1` instead of `0.1`. 

Happy to discuss further. You know where to find me. 

