### PR TITLE
fix: Layout animation jumps when interrupted by another layout animation

### DIFF
--- a/packages/motion-dom/src/animation/JSAnimation.ts
+++ b/packages/motion-dom/src/animation/JSAnimation.ts
@@ -435,7 +435,7 @@ export class JSAnimation<T extends number | string>
     stop = () => {
         const { motionValue } = this.options
         if (motionValue && motionValue.updatedAt !== time.now()) {
-            this.tick(time.now())
+            this.tick(this.holdTime!,true)
         }
 
         this.isStopped = true

--- a/packages/motion-dom/src/animation/JSAnimation.ts
+++ b/packages/motion-dom/src/animation/JSAnimation.ts
@@ -433,10 +433,6 @@ export class JSAnimation<T extends number | string>
      * animation.stop is returned as a reference from a useEffect.
      */
     stop = () => {
-        const { motionValue } = this.options
-        if (motionValue && motionValue.updatedAt !== time.now()) {
-            this.tick(this.holdTime!,true)
-        }
 
         this.isStopped = true
         if (this.state === "idle") return


### PR DESCRIPTION
fix #3195 
- When an animation is interrupted, stop() immediately executes a tick(),forcing the calculation of the current frame's state.
-  This state calculation is based on the current time point, not on the continuity of the animation.  
-  When a new animation starts, it begins from this forcibly calculated state rather than from the smooth transition point of the previous animation.