### PR TITLE
Omitted `value` and `layout` from `ReorderItem`'s props

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -41,7 +41,7 @@ function useDefaultMotionValue(value: any, defaultValue: number = 0) {
 }
 
 type ReorderItemProps<V> = Props<V> &
-    HTMLMotionProps<any> &
+    Omit<HTMLMotionProps<any>, "value" | "layout"> &
     React.PropsWithChildren<{}>
 
 export function ReorderItemComponent<V>(


### PR DESCRIPTION
Close #3204