### PR TITLE
Change default scroll `container` to `scrollingElement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [12.11.1] 2025-05-14
+
+### Fixed
+
+-   Default `scroll` tracking to `document.scrollingElement`.
+
 ## [12.11.0] 2025-05-12
 
 ### Added

--- a/dev/react/src/tests/scroll-spring.tsx
+++ b/dev/react/src/tests/scroll-spring.tsx
@@ -1,0 +1,39 @@
+import { motion, useScroll, useSpring } from "framer-motion"
+import * as React from "react"
+
+export const App = () => {
+    const { scrollYProgress } = useScroll()
+    const springProgress = useSpring(scrollYProgress, {
+        stiffness: 500,
+        damping: 60,
+        restDelta: 0.001,
+    })
+
+    return (
+        <>
+            <div style={{ ...spacer, backgroundColor: "red" }} />
+            <div style={{ ...spacer, backgroundColor: "green" }} />
+            <div style={{ ...spacer, backgroundColor: "blue" }} />
+            <div style={{ ...spacer, backgroundColor: "yellow" }} />
+            <motion.div
+                id="progress"
+                style={{ ...progressStyle, scaleX: springProgress }}
+            >
+                {springProgress}
+            </motion.div>
+        </>
+    )
+}
+
+const spacer = {
+    height: "100vh",
+}
+
+const progressStyle: React.CSSProperties = {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    background: "white",
+    width: "100%",
+    height: 100,
+}

--- a/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
@@ -10,6 +10,13 @@ type Measurements = {
 
 const measurements = new Map<Element, Measurements>()
 
+// Mock scrollingElement for testing
+Object.defineProperty(document, "scrollingElement", {
+    value: document.documentElement,
+    writable: false,
+    configurable: true,
+})
+
 async function nextFrame() {
     return new Promise((resolve) => {
         window.dispatchEvent(new window.Event("scroll"))
@@ -17,7 +24,14 @@ async function nextFrame() {
     })
 }
 
-const createMockMeasurement = (element: Element, name: string) => {
+const createMockMeasurement = (element: Element | null, name: string) => {
+    if (element === null) {
+        console.error("scroll element is null")
+        return (value: number) => {
+            elementMeasurements[name] = value
+        }
+    }
+
     const elementMeasurements = measurements.get(element) || {}
 
     measurements.set(element, elementMeasurements)
@@ -37,15 +51,15 @@ const createMockMeasurement = (element: Element, name: string) => {
 }
 
 const setWindowHeight = createMockMeasurement(
-    document.documentElement,
+    document.scrollingElement,
     "clientHeight"
 )
 const setDocumentHeight = createMockMeasurement(
-    document.documentElement,
+    document.scrollingElement,
     "scrollHeight"
 )
 const setScrollTop = createMockMeasurement(
-    document.documentElement,
+    document.scrollingElement,
     "scrollTop"
 )
 

--- a/packages/framer-motion/src/render/dom/scroll/index.ts
+++ b/packages/framer-motion/src/render/dom/scroll/index.ts
@@ -1,4 +1,5 @@
 import { AnimationPlaybackControls } from "motion-dom"
+import { noop } from "motion-utils"
 import { attachToAnimation } from "./attach-animation"
 import { attachToFunction } from "./attach-function"
 import { OnScroll, ScrollOptions } from "./types"
@@ -7,22 +8,11 @@ export function scroll(
     onScroll: OnScroll | AnimationPlaybackControls,
     {
         axis = "y",
-        container = document.documentElement,
+        container = document.scrollingElement as Element,
         ...options
     }: ScrollOptions = {}
 ): VoidFunction {
-    /**
-     * If the container is the document.documentElement and the scrollHeight
-     * and clientHeight are the same, we need to use the document.body instead
-     * as this is the scrollable document element.
-     */
-    if (
-        container === document.documentElement &&
-        ((axis === "y" && container.scrollHeight === container.clientHeight) ||
-            (axis === "x" && container.scrollWidth === container.clientWidth))
-    ) {
-        container = document.body
-    }
+    if (!container) return noop as VoidFunction
 
     const optionsWithDefaults = { axis, container, ...options }
 

--- a/packages/framer-motion/src/render/dom/scroll/info.ts
+++ b/packages/framer-motion/src/render/dom/scroll/info.ts
@@ -35,7 +35,7 @@ const keys = {
 } as const
 
 function updateAxisInfo(
-    element: HTMLElement,
+    element: Element,
     axisName: "x" | "y",
     info: ScrollInfo,
     time: number
@@ -62,7 +62,7 @@ function updateAxisInfo(
 }
 
 export function updateScrollInfo(
-    element: HTMLElement,
+    element: Element,
     info: ScrollInfo,
     time: number
 ) {

--- a/packages/framer-motion/src/render/dom/scroll/offsets/index.ts
+++ b/packages/framer-motion/src/render/dom/scroll/offsets/index.ts
@@ -14,7 +14,7 @@ function getTargetSize(target: Element) {
 }
 
 export function resolveOffsets(
-    container: HTMLElement,
+    container: Element,
     info: ScrollInfo,
     options: ScrollInfoOptions
 ) {

--- a/packages/framer-motion/src/render/dom/scroll/offsets/inset.ts
+++ b/packages/framer-motion/src/render/dom/scroll/offsets/inset.ts
@@ -1,4 +1,4 @@
-export function calcInset(element: Element, container: HTMLElement) {
+export function calcInset(element: Element, container: Element) {
     const inset = { x: 0, y: 0 }
 
     let current: Element | null = element

--- a/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
+++ b/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
@@ -9,7 +9,7 @@ import {
 } from "./types"
 
 function measure(
-    container: HTMLElement,
+    container: Element,
     target: Element = container,
     info: ScrollInfo
 ) {
@@ -49,7 +49,7 @@ function measure(
 }
 
 export function createOnScrollHandler(
-    element: HTMLElement,
+    element: Element,
     onScroll: OnScrollInfo,
     info: ScrollInfo,
     options: ScrollInfoOptions = {}

--- a/packages/framer-motion/src/render/dom/scroll/track.ts
+++ b/packages/framer-motion/src/render/dom/scroll/track.ts
@@ -1,4 +1,5 @@
 import { cancelFrame, frame, frameData } from "motion-dom"
+import { noop } from "motion-utils"
 import { resize } from "../resize"
 import { createScrollInfo } from "./info"
 import { createOnScrollHandler } from "./on-scroll-handler"
@@ -10,13 +11,18 @@ const onScrollHandlers = new WeakMap<Element, Set<OnScrollHandler>>()
 
 export type ScrollTargets = Array<HTMLElement>
 
-const getEventTarget = (element: HTMLElement) =>
-    element === document.documentElement ? window : element
+const getEventTarget = (element: Element) =>
+    element === document.scrollingElement ? window : element
 
 export function scrollInfo(
     onScroll: OnScrollInfo,
-    { container = document.documentElement, ...options }: ScrollInfoOptions = {}
+    {
+        container = document.scrollingElement as Element,
+        ...options
+    }: ScrollInfoOptions = {}
 ) {
+    if (!container) return noop as VoidFunction
+
     let containerHandlers = onScrollHandlers.get(container)
 
     /**

--- a/packages/framer-motion/src/render/dom/scroll/types.ts
+++ b/packages/framer-motion/src/render/dom/scroll/types.ts
@@ -2,7 +2,7 @@ import { EasingFunction } from "motion-utils"
 
 export interface ScrollOptions {
     source?: HTMLElement
-    container?: HTMLElement
+    container?: Element
     target?: Element
     axis?: "x" | "y"
     offset?: ScrollOffset
@@ -10,7 +10,7 @@ export interface ScrollOptions {
 
 export interface ScrollOptionsWithDefaults extends ScrollOptions {
     axis: "x" | "y"
-    container: HTMLElement
+    container: Element
 }
 
 export type OnScrollProgress = (progress: number) => void
@@ -65,7 +65,7 @@ export type Intersection = `${Edge} ${Edge}`
 export type ScrollOffset = Array<Edge | Intersection | ProgressIntersection>
 
 export interface ScrollInfoOptions {
-    container?: HTMLElement
+    container?: Element
     target?: Element
     axis?: "x" | "y"
     offset?: ScrollOffset

--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -73,12 +73,7 @@ export function useSpring(
             restSpeed: 0.01,
             ...config,
             onUpdate: latestSetter.current,
-            onComplete: () => {
-                value.isEffectActive = true
-            },
         })
-
-        value.isEffectActive = false
     }
 
     const stopAnimation = () => {


### PR DESCRIPTION
As per the `ScrollTimeline` spec, this changes the default scroll container to `document.scrollingElement`

Fixes https://github.com/motiondivision/motion/issues/3206