### PR TITLE
fixed typos in the type definitions and a stale documentation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [12.11.5] 2025-05-16
+
+### Fixed
+
+-   Fixed various typos in the type definitions along with a stale documentation link.
+
 ## [12.11.4] 2025-05-15
 
 ### Fixed

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -44,7 +44,7 @@ export interface AnimationControls {
      * ```
      *
      * @param definition - Properties or variant label to animate to
-     * @param transition - Optional `transtion` to apply to a variant
+     * @param transition - Optional `transition` to apply to a variant
      * @returns - A `Promise` that resolves when all animations have completed.
      *
      * @public

--- a/packages/framer-motion/src/gestures/drag/types.ts
+++ b/packages/framer-motion/src/gestures/drag/types.ts
@@ -163,7 +163,7 @@ export interface DraggableProps extends DragHandlers {
      * Applies constraints on the permitted draggable area.
      *
      * It can accept an object of optional `top`, `left`, `right`, and `bottom` values, measured in pixels.
-     * This will define a distance the named edge of the draggable component.
+     * This will define a distance from the named edge of the draggable component.
      *
      * Alternatively, it can accept a `ref` to another component created with React's `useRef` hook.
      * This `ref` should be passed both to the draggable component's `dragConstraints` prop, and the `ref`
@@ -226,7 +226,7 @@ export interface DraggableProps extends DragHandlers {
     /**
      * Allows you to change dragging inertia parameters.
      * When releasing a draggable Frame, an animation with type `inertia` starts. The animation is based on your dragging velocity. This property allows you to customize it.
-     * See {@link https://framer.com/api/animation/#inertia | Inertia} for all properties you can use.
+     * See {@link https://motion.dev/docs/react-motion-component#dragtransition | Inertia} for all properties you can use.
      *
      * ```jsx
      * <motion.div

--- a/packages/motion-dom/src/utils/interpolate.ts
+++ b/packages/motion-dom/src/utils/interpolate.ts
@@ -54,7 +54,7 @@ function createMixers<T>(
  * mixColor(0.5) // 'rgba(128, 128, 128, 1)'
  * ```
  *
- * TODO Revist this approach once we've moved to data models for values,
+ * TODO Revisit this approach once we've moved to data models for values,
  * probably not needed to pregenerate mixer functions.
  *
  * @public


### PR DESCRIPTION
# typos + stale links

this pull request addresses a few typos, clarity issues and stale links found in the TS definition files. the following changes have been made.

### 1. **packages/framer-motion/src/gestures/drag/types.ts**
  - **Before**: "This will define a distance the named edge of the draggable component."
  - **After**: "This will define the distance `from` the specified edge of the draggable component to the boundary of its constraints."
  - **Description**: Revised for clarity to better explain the intended meaning.

### 2. **packages/framer-motion/src/gestures/drag/types.ts**
  - **Before**: `See {@link https://framer.com/api/animation/#inertia | Inertia}`
  - **After**: `See {@link https://motion.dev/docs/react-motion-component#dragtransition | Inertia}`
  - **Description**: Updated the link to point to the correct documentation for `dragTransition`.

### 3. **packages/framer-motion/src/animation/types.ts**
  - **Before**: `@param transition - Optional `transtion` to apply to a variant`
  - **After**: `@param transition - Optional `transition` to apply to a variant`
  - **Description**: Fixed a typo in the parameter description.

### 4. **packages/framer-motion/src/utils/interpolate.ts**
  - **Before**: `TODO Revist this approach once we've moved to data models for values`
  - **After**: `TODO: Revisit this approach once we've moved to data models for values`
  - **Description**: Corrected the spelling of "Revist" to "Revisit" 


thanks for making an awesome library! 🩵
