### PR TITLE
fix: layout animation interrupt jump

### DIFF
--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -545,10 +545,6 @@ export function createProjectionNode<I>({
                                 this.resumingFrom.resumingFrom = undefined
                             }
 
-                            this.setAnimationOrigin(
-                                delta,
-                                hasOnlyRelativeTargetChanged
-                            )
 
                             const animationOptions = {
                                 ...getValueTransition(
@@ -568,6 +564,14 @@ export function createProjectionNode<I>({
                             }
 
                             this.startAnimation(animationOptions)
+                            /**
+                             * Set animation origin after starting animation to avoid layout jump
+                             * caused by stopping previous layout animation
+                             */
+                             this.setAnimationOrigin(
+                                 delta,
+                                 hasOnlyRelativeTargetChanged
+                             )
                         } else {
                             /**
                              * If the layout hasn't changed and we have an animation that hasn't started yet,
@@ -1599,8 +1603,8 @@ export function createProjectionNode<I>({
         startAnimation(options: ValueAnimationOptions<number>) {
             this.notifyListeners("animationStart")
 
-            this.currentAnimation?.stop(false)
-            this.resumingFrom?.currentAnimation?.stop(false)
+            this.currentAnimation?.stop()
+            this.resumingFrom?.currentAnimation?.stop()
 
             if (this.pendingAnimation) {
                 cancelFrame(this.pendingAnimation)
@@ -1665,7 +1669,7 @@ export function createProjectionNode<I>({
         finishAnimation() {
             if (this.currentAnimation) {
                 this.mixTargetDelta && this.mixTargetDelta(animationTarget)
-                this.currentAnimation.stop(false)
+                this.currentAnimation.stop()
             }
 
             this.completeAnimation()
@@ -2022,7 +2026,7 @@ export function createProjectionNode<I>({
         // Only run on root
         resetTree() {
             this.root.nodes!.forEach((node: IProjectionNode) =>
-                node.currentAnimation?.stop(false)
+                node.currentAnimation?.stop()
             )
             this.root.nodes!.forEach(clearMeasurements)
             this.root.sharedNodes.clear()

--- a/packages/motion-dom/src/animation/JSAnimation.ts
+++ b/packages/motion-dom/src/animation/JSAnimation.ts
@@ -432,12 +432,11 @@ export class JSAnimation<T extends number | string>
      * This method is bound to the instance to fix a pattern where
      * animation.stop is returned as a reference from a useEffect.
      */
-    stop = (sync = true) => {
-        if (sync) {
-            const { motionValue } = this.options
-            if (motionValue && motionValue.updatedAt !== time.now()) {
-                this.tick(time.now())
-            }
+    stop = () => {
+        
+        const { motionValue } = this.options
+        if (motionValue && motionValue.updatedAt !== time.now()) {
+            this.tick(time.now())
         }
 
         this.isStopped = true


### PR DESCRIPTION
- Removed the `sync` parameter from the `stop` method in `JSAnimation` for cleaner usage.
- Moved `setAnimationOrigin` call to after starting the animation in `createProjectionNode` to prevent layout jumps caused by stopping previous animations.