### PR TITLE
Only `notify` scroll updates after `measure`

### DIFF
--- a/dev/html/package.json
+++ b/dev/html/package.json
@@ -1,7 +1,7 @@
 {
     "name": "html-env",
     "private": true,
-    "version": "12.12.1",
+    "version": "12.12.2-alpha.0",
     "type": "module",
     "scripts": {
         "dev": "vite",
@@ -10,8 +10,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "framer-motion": "^12.12.1",
-        "motion": "^12.12.1",
+        "framer-motion": "^12.12.2-alpha.0",
+        "motion": "^12.12.2-alpha.0",
         "motion-dom": "^12.12.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/dev/next/package.json
+++ b/dev/next/package.json
@@ -1,7 +1,7 @@
 {
     "name": "next-env",
     "private": true,
-    "version": "12.12.1",
+    "version": "12.12.2-alpha.0",
     "type": "module",
     "scripts": {
         "dev": "next dev",
@@ -9,7 +9,7 @@
         "start": "next start"
     },
     "dependencies": {
-        "motion": "^12.12.1",
+        "motion": "^12.12.2-alpha.0",
         "next": "14.x",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/dev/react-19/package.json
+++ b/dev/react-19/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-19-env",
     "private": true,
-    "version": "12.12.1",
+    "version": "12.12.2-alpha.0",
     "type": "module",
     "scripts": {
         "dev": "vite",
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "motion": "^12.12.1",
+        "motion": "^12.12.2-alpha.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
     },

--- a/dev/react/package.json
+++ b/dev/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-env",
     "private": true,
-    "version": "12.12.1",
+    "version": "12.12.2-alpha.0",
     "type": "module",
     "scripts": {
         "dev": "vite",
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "framer-motion": "^12.12.1",
+        "framer-motion": "^12.12.2-alpha.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "12.12.1",
+  "version": "12.12.2-alpha.0",
   "packages": [
     "packages/*",
     "dev/*"

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "12.12.1",
+    "version": "12.12.2-alpha.0",
     "description": "A simple and powerful JavaScript animation library",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",

--- a/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
+++ b/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
@@ -55,8 +55,8 @@ export function createOnScrollHandler(
     options: ScrollInfoOptions = {}
 ): OnScrollHandler {
     return {
-        measure: () => measure(element, options.target, info),
-        update: (time) => {
+        measure: (time) => {
+            measure(element, options.target, info)
             updateScrollInfo(element, info, time)
 
             if (options.offset || options.target) {

--- a/packages/framer-motion/src/render/dom/scroll/track.ts
+++ b/packages/framer-motion/src/render/dom/scroll/track.ts
@@ -53,8 +53,7 @@ export function scrollInfo(
     if (!scrollListeners.has(container)) {
         const measureAll = () => {
             for (const handler of containerHandlers) {
-                handler.measure()
-                handler.update(frameData.timestamp)
+                handler.measure(frameData.timestamp)
             }
 
             frame.preUpdate(notifyAll)

--- a/packages/framer-motion/src/render/dom/scroll/track.ts
+++ b/packages/framer-motion/src/render/dom/scroll/track.ts
@@ -53,6 +53,8 @@ export function scrollInfo(
     if (!scrollListeners.has(container)) {
         const measureAll = () => {
             for (const handler of containerHandlers!) handler.measure()
+            updateAll()
+            frame.preUpdate(notifyAll)
         }
 
         const updateAll = () => {
@@ -67,8 +69,6 @@ export function scrollInfo(
 
         const listener = () => {
             frame.read(measureAll)
-            frame.read(updateAll)
-            frame.preUpdate(notifyAll)
         }
 
         scrollListeners.set(container, listener)

--- a/packages/framer-motion/src/render/dom/scroll/track.ts
+++ b/packages/framer-motion/src/render/dom/scroll/track.ts
@@ -52,24 +52,21 @@ export function scrollInfo(
      */
     if (!scrollListeners.has(container)) {
         const measureAll = () => {
-            for (const handler of containerHandlers!) handler.measure()
-            updateAll()
+            for (const handler of containerHandlers) {
+                handler.measure()
+                handler.update(frameData.timestamp)
+            }
+
             frame.preUpdate(notifyAll)
         }
 
-        const updateAll = () => {
-            for (const handler of containerHandlers!) {
-                handler.update(frameData.timestamp)
+        const notifyAll = () => {
+            for (const handler of containerHandlers) {
+                handler.notify()
             }
         }
 
-        const notifyAll = () => {
-            for (const handler of containerHandlers!) handler.notify()
-        }
-
-        const listener = () => {
-            frame.read(measureAll)
-        }
+        const listener = () => frame.read(measureAll)
 
         scrollListeners.set(container, listener)
 

--- a/packages/framer-motion/src/render/dom/scroll/types.ts
+++ b/packages/framer-motion/src/render/dom/scroll/types.ts
@@ -43,8 +43,7 @@ export interface ScrollInfo {
 export type OnScrollInfo = (info: ScrollInfo) => void
 
 export type OnScrollHandler = {
-    measure: () => void
-    update: (time: number) => void
+    measure: (time: number) => void
     notify: () => void
 }
 

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -1,6 +1,6 @@
 {
     "name": "motion",
-    "version": "12.12.1",
+    "version": "12.12.2-alpha.0",
     "description": "An animation library for JavaScript and React.",
     "main": "dist/cjs/index.js",
     "module": "dist/es/motion/lib/index.mjs",
@@ -76,7 +76,7 @@
         "postpublish": "git push --tags"
     },
     "dependencies": {
-        "framer-motion": "^12.12.1",
+        "framer-motion": "^12.12.2-alpha.0",
         "tslib": "^2.4.0"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6848,7 +6848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@^12.12.1, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^12.12.2-alpha.0, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:
@@ -7612,8 +7612,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "html-env@workspace:dev/html"
   dependencies:
-    framer-motion: ^12.12.1
-    motion: ^12.12.1
+    framer-motion: ^12.12.2-alpha.0
+    motion: ^12.12.2-alpha.0
     motion-dom: ^12.12.1
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -10417,11 +10417,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"motion@^12.12.1, motion@workspace:packages/motion":
+"motion@^12.12.2-alpha.0, motion@workspace:packages/motion":
   version: 0.0.0-use.local
   resolution: "motion@workspace:packages/motion"
   dependencies:
-    framer-motion: ^12.12.1
+    framer-motion: ^12.12.2-alpha.0
     tslib: ^2.4.0
   peerDependencies:
     "@emotion/is-prop-valid": "*"
@@ -10538,7 +10538,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "next-env@workspace:dev/next"
   dependencies:
-    motion: ^12.12.1
+    motion: ^12.12.2-alpha.0
     next: 14.x
     react: ^18.3.1
     react-dom: ^18.3.1
@@ -12001,7 +12001,7 @@ __metadata:
     "@typescript-eslint/parser": ^7.2.0
     "@vitejs/plugin-react-swc": ^3.5.0
     eslint-plugin-react-refresh: ^0.4.6
-    motion: ^12.12.1
+    motion: ^12.12.2-alpha.0
     react: ^19.0.0
     react-dom: ^19.0.0
     vite: ^5.2.0
@@ -12073,7 +12073,7 @@ __metadata:
     "@typescript-eslint/parser": ^7.2.0
     "@vitejs/plugin-react-swc": ^3.5.0
     eslint-plugin-react-refresh: ^0.4.6
-    framer-motion: ^12.12.1
+    framer-motion: ^12.12.2-alpha.0
     react: ^18.3.1
     react-dom: ^18.3.1
     vite: ^5.2.0


### PR DESCRIPTION
Previously, the scroll listener would schedule reads and writes at the same time.

```javascript
const listener = () => {
    frame.read(measureAll)
    frame.read(updateAll) // read
    frame.preUpdate(notifyAll) // write
}
```

If this `listener` was called somewhere between the `read` and `preUpdate` steps then the `read` would be scheduled for the following frame and the `preUpdate` would trigger in the current frame.

This update ensures `notifyAll` is only triggered in the same frame as the `measureAll` by moving `frame.preUpdate(notifyAll)` into `measureAll`.