### PR TITLE
Add support for defining a timeline position relative to the start of the most recently added animation (e.g. `<0.5`, `<-1`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [12.17.0] 2025-06-08
+
+### Added
+
+-   Support for defining timeline position relative to the start of the most recently-added animation (e.g. `<0.5`, `<-1`)
+
 ## [12.16.0] 2025-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Undocumented APIs should be considered internal and may change without warning.
 
 ### Added
 
--   Support for defining timeline position relative to the start of the most recently-added animation (e.g. `<0.5`, `<-1`)
+-   Support for defining a timeline position relative to the start of the most recently added animation (e.g. `<0.5`, `<-1`)
 
 ## [12.16.0] 2025-06-03
 

--- a/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-time.test.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-time.test.ts
@@ -20,5 +20,12 @@ describe("calcNextTime", () => {
 
         // Previous
         expect(calcNextTime(5, "<", 100, labels)).toBe(100)
+
+        // Relative to previous
+        expect(calcNextTime(5, "<1", 100, labels)).toBe(101)
+        expect(calcNextTime(5, "<-1", 100, labels)).toBe(99)
+        expect(calcNextTime(5, "<2.5", 100, labels)).toBe(102.5)
+        expect(calcNextTime(5, "<-2.5", 100, labels)).toBe(97.5)
+        expect(calcNextTime(5, "<-150", 100, labels)).toBe(0)
     })
 })

--- a/packages/framer-motion/src/animation/sequence/utils/calc-time.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/calc-time.ts
@@ -16,6 +16,8 @@ export function calcNextTime(
         return Math.max(0, current + parseFloat(next))
     } else if (next === "<") {
         return prev
+    } else if (next.startsWith("<")) {
+        return Math.max(0, prev + parseFloat(next.slice(1)))
     } else {
         return labels.get(next) ?? current
     }


### PR DESCRIPTION
This is something I'm really missing ever since switching from GSAP.