### PR TITLE
fix: #3260 keep sub-pixel `width/height` when snapshotting exit layout to eliminate 1-px shift

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -34,16 +34,17 @@ class PopChildMeasure extends React.Component<MeasureProps> {
         const element = this.props.childRef.current
         if (element && prevProps.isPresent && !this.props.isPresent) {
             const parent = element.offsetParent
-            const parentWidth = isHTMLElement(parent)
-                ? parent.offsetWidth || 0
-                : 0
+            const parentRect = isHTMLElement(parent)
+                ? parent.getBoundingClientRect()
+                : { width: 0 }
 
+            const rect = element.getBoundingClientRect()
             const size = this.props.sizeRef.current!
-            size.height = element.offsetHeight || 0
-            size.width = element.offsetWidth || 0
+            size.height = rect.height
+            size.width = rect.width
             size.top = element.offsetTop
             size.left = element.offsetLeft
-            size.right = parentWidth - size.width - size.left
+            size.right = parentRect.width - size.width - size.left
         }
 
         return null


### PR DESCRIPTION
This PR fixes #3260.

This is just a preliminary modification and has not undergone very thorough testing. Any suggestions and changes are very welcome.

## The Issue

When `AnimatePresence` runs in `mode="popLayout"`, it captures the exiting node’s geometry inside  
`PopChildMeasure.getSnapshotBeforeUpdate`.

The current implementation relies on `offsetWidth/offsetHeight`, which are always rounded to integers, so an element that is **400.4 px** wide becomes **400 px** the instant it is promoted to `position:absolute`.  That 1-px delta produces a visible layout shift on the very first frame of the exit animation.

This PR replaces those integer measurements with `getBoundingClientRect()` so that the stored `width`/`height` retain full floating-point precision. The change is strictly internal: public API and type signatures remain unchanged.