### PR TITLE
Don't suspend layout animations on iOS when scrolling

### DIFF
--- a/packages/framer-motion/src/events/add-resize-event.ts
+++ b/packages/framer-motion/src/events/add-resize-event.ts
@@ -1,0 +1,26 @@
+/* 
+  iOS will trigger a resize event when:
+  - The keyboard is shown or hidden
+  - The address bar is shown or hidden
+
+  This causes layout animations to suspend when scrolling which can be undesirable.
+  Instead of listening to the resize event as is, we compare the window width
+  between events and only invoke and thus suspend layout animations if the width actually changes.
+*/
+export function addResizeEvent(
+    target: EventTarget,
+    handler: EventListener,
+    options: AddEventListenerOptions = { passive: true }
+) {
+    let initialWidth = window.innerWidth
+
+    function resize(event: Event) {
+        if (window.innerWidth !== initialWidth) {
+            initialWidth = window.innerWidth
+            handler(event)
+        }
+    }
+
+    target.addEventListener("resize", resize, options)
+    return () => target.removeEventListener("resize", resize)
+}

--- a/packages/framer-motion/src/projection/node/DocumentProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/DocumentProjectionNode.ts
@@ -1,11 +1,11 @@
 import { createProjectionNode } from "./create-projection-node"
-import { addDomEvent } from "../../events/add-dom-event"
+import { addResizeEvent } from "../../events/add-resize-event"
 
 export const DocumentProjectionNode = createProjectionNode<Window>({
     attachResizeListener: (
         ref: Window | Element,
         notify: VoidFunction
-    ): VoidFunction => addDomEvent(ref, "resize", notify),
+    ): VoidFunction => addResizeEvent(ref, notify),
     measureScroll: () => ({
         x: document.documentElement.scrollLeft || document.body.scrollLeft,
         y: document.documentElement.scrollTop || document.body.scrollTop,


### PR DESCRIPTION
This PR resolves https://github.com/motiondivision/motion/issues/3267.

Namely, as I understood from our chat with @mattgperry layout animations suspend on window `resize` events. Unfortunately iOS triggers a `resize` event when the address bar expands or collapses based on scroll position. 

The fix could be to compare window width between events and suspend only if there is an actual change to the window width.

> Note: comparing height will not yield the result we want; height actually changes as a side effect of the address bar movement