### PR TITLE
Fix Safari zoom shrinking SVG path animations

### DIFF
--- a/packages/framer-motion/src/render/svg/utils/__tests__/path.test.ts
+++ b/packages/framer-motion/src/render/svg/utils/__tests__/path.test.ts
@@ -10,7 +10,7 @@ describe("buildSVGPath", () => {
 
         buildSVGPath(attrs, 0.5, 0.25, 0.25)
 
-        expect(attrs["stroke-dashoffset"]).toBe("-0.25px")
-        expect(attrs["stroke-dasharray"]).toBe("0.5px 0.25px")
+        expect(attrs["stroke-dashoffset"]).toBe("-0.25")
+        expect(attrs["stroke-dasharray"]).toBe("0.5 0.25")
     })
 })

--- a/packages/framer-motion/src/render/svg/utils/path.ts
+++ b/packages/framer-motion/src/render/svg/utils/path.ts
@@ -1,4 +1,3 @@
-import { px } from "motion-dom"
 import { ResolvedValues } from "../../types"
 
 const dashKeys = {
@@ -20,9 +19,9 @@ const camelKeys = {
  */
 export function buildSVGPath(
     attrs: ResolvedValues,
-    length: number,
-    spacing = 1,
-    offset = 0,
+    length: number | string,
+    spacing: number | string = 1,
+    offset: number | string = 0,
     useDashCase: boolean = true
 ): void {
     // Normalise path length by setting SVG attribute pathLength to 1
@@ -32,11 +31,12 @@ export function buildSVGPath(
     // when defining props on a React component.
     const keys = useDashCase ? dashKeys : camelKeys
 
-    // Build the dash offset
-    attrs[keys.offset] = px.transform!(-offset)
+    // Build the dash offset (unitless so zooming doesn't affect rendering)
+    const offsetValue = typeof offset === "string" ? -parseFloat(offset) : -offset
+    attrs[keys.offset] = `${offsetValue}`
 
-    // Build the dash array
-    const pathLength = px.transform!(length)
-    const pathSpacing = px.transform!(spacing)
-    attrs[keys.array] = `${pathLength} ${pathSpacing}`
+    // Build the dash array (unitless for the same reason)
+    const lengthValue = typeof length === "string" ? length : `${length}`
+    const spacingValue = typeof spacing === "string" ? spacing : `${spacing}`
+    attrs[keys.array] = `${lengthValue} ${spacingValue}`
 }

--- a/packages/motion-dom/src/effects/__tests__/svg-effect.test.ts
+++ b/packages/motion-dom/src/effects/__tests__/svg-effect.test.ts
@@ -213,8 +213,8 @@ describe("svgEffect", () => {
 
         // Verify initial path properties
         expect(element.getAttribute("pathLength")).toBe("1")
-        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.5px")
-        expect(element.getAttribute("stroke-dasharray")).toBe("2px 1px")
+        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.5")
+        expect(element.getAttribute("stroke-dasharray")).toBe("2 1")
 
         // Update values
         pathOffset.set("0.25")
@@ -225,8 +225,8 @@ describe("svgEffect", () => {
 
         // Verify updated path properties
         expect(element.getAttribute("pathLength")).toBe("1")
-        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.25px")
-        expect(element.getAttribute("stroke-dasharray")).toBe("3px 2px")
+        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.25")
+        expect(element.getAttribute("stroke-dasharray")).toBe("3 2")
     })
 
     it("handles path properties with cleanup", async () => {
@@ -248,8 +248,8 @@ describe("svgEffect", () => {
         await nextFrame()
 
         // Verify initial values
-        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.5px")
-        expect(element.getAttribute("stroke-dasharray")).toBe("2px 1px")
+        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.5")
+        expect(element.getAttribute("stroke-dasharray")).toBe("2 1")
 
         // Update values
         pathOffset.set("0.25")
@@ -259,8 +259,8 @@ describe("svgEffect", () => {
         await nextFrame()
 
         // Verify updates
-        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.25px")
-        expect(element.getAttribute("stroke-dasharray")).toBe("3px 2px")
+        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.25")
+        expect(element.getAttribute("stroke-dasharray")).toBe("3 2")
 
         // Cleanup
         cleanup()
@@ -273,7 +273,7 @@ describe("svgEffect", () => {
         await nextFrame()
 
         // Verify values didn't change after cleanup
-        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.25px")
-        expect(element.getAttribute("stroke-dasharray")).toBe("3px 2px")
+        expect(element.getAttribute("stroke-dashoffset")).toBe("-0.25")
+        expect(element.getAttribute("stroke-dasharray")).toBe("3 2")
     })
 })

--- a/packages/motion-dom/src/effects/svg/index.ts
+++ b/packages/motion-dom/src/effects/svg/index.ts
@@ -1,13 +1,10 @@
 import { frame } from "../../frameloop"
 import { MotionValue } from "../../value"
-import { px } from "../../value/types/numbers/units"
 import { addAttrValue } from "../attr"
 import { MotionValueState } from "../MotionValueState"
 import { addStyleValue } from "../style"
 import { createSelectorEffect } from "../utils/create-dom-effect"
 import { createEffect } from "../utils/create-effect"
-
-const toPx = px.transform!
 
 function addSVGPathValue(
     element: SVGElement,
@@ -18,19 +15,30 @@ function addSVGPathValue(
     frame.render(() => element.setAttribute("pathLength", "1"))
 
     if (key === "pathOffset") {
+        const offset = state.latest[key]
+        const offsetValue = typeof offset === "string" ? -parseFloat(offset) : -offset
         return state.set(key, value, () =>
-            element.setAttribute("stroke-dashoffset", toPx(-state.latest[key]))
+            element.setAttribute("stroke-dashoffset", `${offsetValue}`)
         )
     } else {
         if (!state.get("stroke-dasharray")) {
             state.set("stroke-dasharray", new MotionValue("1 1"), () => {
                 const { pathLength = 1, pathSpacing } = state.latest
 
+                const lengthValue =
+                    typeof pathLength === "string"
+                        ? pathLength
+                        : `${pathLength}`
+
+                const spacingRaw = pathSpacing ?? 1 - Number(pathLength)
+                const spacingValue =
+                    typeof spacingRaw === "string"
+                        ? spacingRaw
+                        : `${spacingRaw}`
+
                 element.setAttribute(
                     "stroke-dasharray",
-                    `${toPx(pathLength)} ${toPx(
-                        pathSpacing ?? 1 - Number(pathLength)
-                    )}`
+                    `${lengthValue} ${spacingValue}`
                 )
             })
         }

--- a/tests/effects/svg.spec.ts
+++ b/tests/effects/svg.spec.ts
@@ -5,7 +5,7 @@ test.describe("svgEffect", () => {
         await page.goto("effects/path-length.html")
         const path = page.locator("#tick")
         const strokeDasharray = await path.getAttribute("stroke-dasharray")
-        expect(strokeDasharray).toBe("0.25px 0.75px")
+        expect(strokeDasharray).toBe("0.25 0.75")
         const pathLength = await path.getAttribute("pathLength")
         expect(pathLength).toBe("1")
     })
@@ -14,7 +14,7 @@ test.describe("svgEffect", () => {
         await page.goto("effects/path-offset.html")
         const path = page.locator("#tick")
         const strokeDashoffset = await path.getAttribute("stroke-dashoffset")
-        expect(strokeDashoffset).toBe("-0.5px")
+        expect(strokeDashoffset).toBe("-0.5")
     })
 
     test("ensures default pathSpacing correctly creates looping effect by calculating remaining amount", async ({
@@ -23,9 +23,9 @@ test.describe("svgEffect", () => {
         await page.goto("effects/path-offset-loop.html")
         const circle = page.locator("#circle")
         const strokeDasharray = await circle.getAttribute("stroke-dasharray")
-        expect(strokeDasharray).toBe("0.5px 0.5px")
+        expect(strokeDasharray).toBe("0.5 0.5")
         const strokeDashoffset = await circle.getAttribute("stroke-dashoffset")
-        expect(strokeDashoffset).toBe("-0.75px")
+        expect(strokeDashoffset).toBe("-0.75")
     })
 
     test("draws attrX as x", async ({ page }) => {


### PR DESCRIPTION
Closes #3301

## Background

Safari (macOS / iOS) rescales dash-pattern values expressed with absolute units (`px`) whenever the user zooms the page. Because Motion currently serialises the custom `pathLength`, `pathSpacing` and `pathOffset` props as `"Xpx Ypx"`, zooming makes the visible stroke shorter and shorter (see #3301).  Chrome keeps the pattern stable and renders correctly.

## What this PR does

1. **Emit unit-less numbers** for `stroke-dasharray` and `stroke-dashoffset`. Safari leaves these unchanged while zooming, restoring parity with other browsers.
2. **Broaden typings** – `buildSVGPath` now accepts `number | string`.
3. **Remove `px` helper** where no longer needed.
4. **Update tests** to expect the new unit-less output.

### File overview

| File | Key changes |
|------|-------------|
| `packages/framer-motion/src/render/svg/utils/path.ts` | • Drop `px` transform<br>• Build unit-less dash values<br>• Accepts `number`, or `string` |
| `packages/motion-dom/src/effects/svg/index.ts`        | • Remove `px` helper import<br>• Write unit-less dash values at runtime |
| **Tests**                                             | Expectations updated in:<br>  • `tests/effects/svg.spec.ts`<br>  • `packages/motion-dom/src/effects/__tests__/svg-effect.test.ts`<br>  • `packages/framer-motion/src/render/svg/utils/__tests__/path.test.ts` |

### Behaviour before vs after (Safari)

| Zoom | Previous `stroke-dasharray` | Result | New `stroke-dasharray` | Result |
|------|----------------------------|--------|------------------------|--------|
| 100 % | `0.25px 0.75px` | ✅ Full stroke | `0.25 0.75` | ✅ Full stroke |
|  80 % | `0.20px 0.60px` *(scaled)* | ❌ Clipped | `0.25 0.75` | ✅ Full stroke |

### Manual test

```bash
git clone https://github.com/motiondivision/motion.git
cd motion
make bootstrap
yarn dev
# open Safari → http://localhost:9991/?example=SVG-path
# play the animation at 100 %, 90 %, 80 % … stroke now remains correct
```