### PR TITLE
Create two-pass initialisation for `useScroll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ Undocumented APIs should be considered internal and may change without warning.
 
 ### Changed
 
--   Allow `useScroll` to retry initialising scroll animation within a `useEffect`.
--   Changed unhydrated ref warning to error.
+-   `useScroll`: Re-attempt to initialise scroll animation within a `useEffect` if refs weren't hydrated during the `useLayoutEffect`. Throw if refs are still not hydrated during the `useEffect`.
 
 ## [12.23.0] 2025-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [12.23.1] 2025-07-08
+
+### Changed
+
+-   Allow `useScroll` to retry initialising scroll animation within a `useEffect`.
+-   Changed unhydrated ref warning to error.
+
 ## [12.23.0] 2025-07-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test-e2e: test-nextjs test-html test-react test-react-19
 	yarn test-playwright
 
 test-single: build test-mkdir
-	yarn start-server-and-test "yarn dev-server" http://localhost:9991 "cd packages/framer-motion && cypress run --config-file=cypress.react-19.json --headed --spec cypress/integration/layout-read-transform.ts"
+	yarn start-server-and-test "yarn dev-server" http://localhost:9991 "cd packages/framer-motion && cypress run --config-file=cypress.react-19.json --headed --spec cypress/integration/scroll.ts"
 
 lint: bootstrap
 	yarn lint

--- a/dev/react/src/tests/scroll-explicit-height.tsx
+++ b/dev/react/src/tests/scroll-explicit-height.tsx
@@ -1,0 +1,102 @@
+import { motion, useScroll, useTransform } from "framer-motion"
+import * as React from "react"
+import { ReactNode, useRef } from "react"
+
+const BubbleParallax: React.FC<{
+    children: ReactNode
+    id: string
+    containerRef: React.RefObject<HTMLElement>
+}> = ({ children, containerRef, id }) => {
+    const ref = useRef<HTMLDivElement>(null)
+
+    const { scrollYProgress } = useScroll({
+        target: ref,
+        container: containerRef,
+        offset: ["start end", "end start"],
+    })
+
+    const opacity = useTransform(scrollYProgress, (progressValue) => {
+        const axis = 2 * progressValue - 1
+        return -Math.abs(axis) + 1
+    })
+
+    return (
+        <motion.div
+            id={id}
+            ref={ref}
+            style={{
+                opacity,
+                marginBottom: "50px",
+            }}
+        >
+            {children}
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                height: "100vh",
+                backgroundColor: "#E0E0E0",
+            }}
+        >
+            <div
+                id="scroll-container"
+                ref={scrollContainerRef}
+                style={{
+                    width: "100%",
+                    height: "80vh", // ❌ This breaks in React 19
+                    overflowY: "scroll",
+                    backgroundColor: "#1A237E",
+                    padding: "20px",
+                    boxSizing: "border-box",
+                    borderRadius: "8px",
+                }}
+            >
+                <div
+                    style={{
+                        color: "white",
+                        textAlign: "center",
+                        fontSize: "2rem",
+                        padding: "40px 0",
+                    }}
+                >
+                    Parallax Area
+                </div>
+
+                {[...Array(10)].map((_, index) => {
+                    return (
+                        <BubbleParallax
+                            key={index}
+                            containerRef={scrollContainerRef}
+                            id={"item-" + index}
+                        >
+                            <div
+                                style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                    width: "100%",
+                                    height: "300px",
+                                    backgroundColor: "#BBDEFB",
+                                    fontSize: "5rem",
+                                    color: "#1A237E",
+                                    borderRadius: "10px",
+                                }}
+                            >
+                                {index + 1}
+                            </div>
+                        </BubbleParallax>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/scroll.ts
+++ b/packages/framer-motion/cypress/integration/scroll.ts
@@ -309,15 +309,13 @@ describe("scroll() full height target", () => {
 describe("scroll() container tracking", () => {
     it("correctly tracks position of a target with container of fixed height", () => {
         cy.visit("?test=scroll-explicit-height")
-            .wait(100)
-            .get("#scroll-container")
-            .viewport(800, 500)
-            .scrollTo(0, 1000)
+            .viewport(800, 800)
             .wait(100)
             .get("#item-0")
             .should(([$element]: any) => {
                 expect($element.style.opacity).to.equal("0")
             })
+            .get("#scroll-container")
             .scrollTo(0, 1000)
             .wait(100)
             .get("#item-2")

--- a/packages/framer-motion/cypress/integration/scroll.ts
+++ b/packages/framer-motion/cypress/integration/scroll.ts
@@ -305,3 +305,25 @@ describe("scroll() full height target", () => {
             })
     })
 })
+
+describe("scroll() container tracking", () => {
+    it("correctly tracks position of a target with container of fixed height", () => {
+        cy.visit("?test=scroll-explicit-height")
+            .wait(100)
+            .get("#scroll-container")
+            .viewport(800, 500)
+            .scrollTo(0, 1000)
+            .wait(100)
+            .get("#item-0")
+            .should(([$element]: any) => {
+                expect($element.style.opacity).to.equal("0")
+            })
+            .scrollTo(0, 1000)
+            .wait(100)
+            .get("#item-2")
+            .should(([$element]: any) => {
+                expect($element.style.opacity).not.to.equal("0")
+                expect($element.style.opacity).not.to.equal("1")
+            })
+    })
+})

--- a/packages/framer-motion/src/value/use-scroll.ts
+++ b/packages/framer-motion/src/value/use-scroll.ts
@@ -77,11 +77,13 @@ export function useScroll({
         if (needsStart.current) {
             invariant(
                 !isRefPending(container),
-                "Container ref is defined but not hydrated"
+                "Container ref is defined but not hydrated",
+                "use-scroll-ref"
             )
             invariant(
                 !isRefPending(target),
-                "Target ref is defined but not hydrated"
+                "Target ref is defined but not hydrated",
+                "use-scroll-ref"
             )
             return start()
         } else {


### PR DESCRIPTION
Fixes https://github.com/motiondivision/motion/issues/3303

Re-attempt to initialise scroll animation within a `useEffect` if refs weren't hydrated during the `useLayoutEffect`. Throw if refs are still not hydrated during the `useEffect`.