### PR TITLE
Disable WAAPI within popups

### DIFF
--- a/packages/motion-dom/src/animation/waapi/supports/waapi.ts
+++ b/packages/motion-dom/src/animation/waapi/supports/waapi.ts
@@ -1,5 +1,4 @@
 import { memo } from "motion-utils"
-import { isHTMLElement } from "../../../utils/is-html-element"
 import {
     AnyResolvedKeyframe,
     ValueAnimationOptionsWithRenderContext,
@@ -29,7 +28,13 @@ export function supportsBrowserAnimation<T extends AnyResolvedKeyframe>(
 
     const subject = motionValue?.owner?.current
 
-    if (!isHTMLElement(subject) || !(subject instanceof Element)) {
+    /**
+     * We use this check instead of isHTMLElement() because we explicitly
+     * **don't** want elements in different timing contexts (i.e. popups)
+     * to be accelerated, as it's not possible to sync these animations
+     * properly with those driven from the main window frameloop.
+     */
+    if (!(subject instanceof HTMLElement)) {
         return false
     }
 

--- a/packages/motion-dom/src/animation/waapi/supports/waapi.ts
+++ b/packages/motion-dom/src/animation/waapi/supports/waapi.ts
@@ -27,11 +27,13 @@ export function supportsBrowserAnimation<T extends AnyResolvedKeyframe>(
     const { motionValue, name, repeatDelay, repeatType, damping, type } =
         options
 
-    if (!isHTMLElement(motionValue?.owner?.current)) {
+    const subject = motionValue?.owner?.current
+
+    if (!isHTMLElement(subject) || !(subject instanceof Element)) {
         return false
     }
 
-    const { onUpdate, transformTemplate } = motionValue.owner.getProps()
+    const { onUpdate, transformTemplate } = motionValue!.owner!.getProps()
 
     return (
         supportsWaapi() &&


### PR DESCRIPTION
Fixes https://github.com/motiondivision/motion/issues/3300

This PR disables WAAPI in popups as it's not straightforward to synchronise timings between these animations and those being driven from the main frameloop.