### PR TITLE
fix: eliminate redundant removeChild

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -108,8 +108,6 @@ export function PopChild({ children, isPresent, anchorX, root }: Props) {
         }
 
         return () => {
-            parent.removeChild(style)
-
             if (parent.contains(style)) {
                 parent.removeChild(style)
             }


### PR DESCRIPTION
Eliminate redundant removeChild call for the injected style element, seems to have slipped in on a previous refactor