### PR TITLE
Fixes #3320 — when a draggable element is inside a rotated parent, its drag direction is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [12.23.6] 2025-07-21
+
+### Fixed
+
+-   Fixed drag direction when a draggable is inside a rotated parent container; it now moves with the cursor 
+
 ## [12.23.6] 2025-07-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
-## [12.23.6] 2025-07-21
-
-### Fixed
-
--   Fixed drag direction when a draggable is inside a rotated parent container; it now moves with the cursor 
-
 ## [12.23.6] 2025-07-11
 
 ### Changed

--- a/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
@@ -62,6 +62,96 @@ describe("dragging", () => {
         pointer.end()
     })
 
+    test("draggable element moves correctly in the X direction when inside a rotated parent", async () => {
+        const Component = (): JSX.Element => (
+            <MockDrag>
+                <motion.div style={{ transform: "rotate(180deg)" }}>
+                    <motion.div
+                        data-testid="draggable"
+                        drag="x"
+                        dragTransition={{
+                            bounceStiffness: 100000,
+                            bounceDamping: 100000,
+                        }}
+                        style={{
+                            width: 100,
+                            height: 100,
+                            background: "red",
+                        }}
+                    />
+                </motion.div>
+            </MockDrag>
+        )
+
+        const { container, getByTestId, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        const draggable = getByTestId("draggable")
+        const dragTarget = container.firstChild?.firstChild as HTMLElement
+
+        const pointer = await drag(dragTarget).to(100, 0)
+        await nextFrame()
+
+        const transform = draggable.style.transform
+        const translateXMatch = transform.match(/translateX\(\s*([\d.-]+)px\)/)
+
+        expect(translateXMatch).not.toBeNull()
+        expect(translateXMatch).toBeTruthy()
+
+        const translateXValue = parseFloat(translateXMatch![1])
+        expect(translateXValue).not.toBeNaN()
+        expect(translateXValue).toBeCloseTo(100, 1)
+
+        expect(transform).not.toMatch(/translateY/)
+
+        pointer.end()
+    })
+
+    test("draggable element moves correctly in the Y direction when inside a rotated parent", async () => {
+        const Component = (): JSX.Element => (
+            <MockDrag>
+                <motion.div style={{ transform: "rotate(180deg)" }}>
+                    <motion.div
+                        data-testid="draggable"
+                        drag="y"
+                        dragTransition={{
+                            bounceStiffness: 100000,
+                            bounceDamping: 100000,
+                        }}
+                        style={{
+                            width: 100,
+                            height: 100,
+                            background: "red",
+                        }}
+                    />
+                </motion.div>
+            </MockDrag>
+        )
+
+        const { container, getByTestId, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        const draggable = getByTestId("draggable")
+        const dragTarget = container.firstChild?.firstChild as HTMLElement
+
+        const pointer = await drag(dragTarget).to(0, 100)
+        await nextFrame()
+
+        const transform = draggable.style.transform
+        const translateYMatch = transform.match(/translateY\(\s*([\d.-]+)px\)/)
+
+        expect(translateYMatch).not.toBeNull()
+        expect(translateYMatch).toBeTruthy()
+
+        const translateYValue = parseFloat(translateYMatch![1])
+        expect(translateYValue).not.toBeNaN()
+        expect(translateYValue).toBeCloseTo(100, 1)
+
+        expect(transform).not.toMatch(/translateX/)
+
+        pointer.end()
+    })
+
     test("willChange is applied correctly when other values are animating", async () => {
         const Component = () => {
             const willChange = useWillChange()


### PR DESCRIPTION
Closes #3320

This PR modifies the drag logic to correctly handle draggables inside rotated parent containers.

| File                                                                   | Key Changes                                                                                                     |
|------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| `packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts` | - Changed `updateAxis` to check if a draggable has a rotated parent. <br>- Added `checkForRotatedParent` helper function to detect rotation in the parent. <br>- Added `calculatedInverseMatrix` helper function to create the inverse rotation matrix of the parent container's rotation. <br>- Added `calculateInvertedPoint` helper function to multiply the inverse matrix with the offset. |
| `packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx` | - Added tests for proper x and y positions of a draggable child in a rotated parent. |

This is my first contribution to an open source project, so any feedback would be greatly appreciated. Thank you!
