### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/dev/html/public/optimized-appear/defer-handoff-suspense.html
+++ b/dev/html/public/optimized-appear/defer-handoff-suspense.html
@@ -94,7 +94,7 @@
 
                                     const { width, left } =
                                         box.getBoundingClientRect()
-                                    // the width scales with the parent, e.g. if the parent scales 2x, the child scales scales 2x on top
+                                    // the width scales with the parent, e.g. if the parent scales 2x, the child scales 2x on top
                                     if (Math.round(width) !== 200 * i) {
                                         showError(
                                             box,


### PR DESCRIPTION
remove redundant word in comment