### PR TITLE
fix(#3372): null context in AnimatePresence

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -165,7 +165,7 @@ export const AnimatePresence = ({
      * we can use it to force a re-render amongst all surrounding components once
      * all components have finished animating out.
      */
-    const { forceRender } = useContext(LayoutGroupContext)
+    const { forceRender } = useContext(LayoutGroupContext) || {}
 
     return (
         <>


### PR DESCRIPTION
Defaulting LayoutGroupContext value to an empty object to fix #3372.

Console errors like this when the context is null:

```
ReactDebugToolsRenderError: Error rendering inspected component
...
Caused by: TypeError: import_react10.useContext(...) is null
    AnimatePresence index.mjs:134
    inspectHooks <anonymous code>:1
...
    _wallUnlisten 
```