### PR TITLE
Fix Reorder.Group to accept union array types

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -175,10 +175,16 @@ export function ReorderGroupComponent<
 }
 
 export const ReorderGroup = /*@__PURE__*/ forwardRef(ReorderGroupComponent) as <
-    V,
+    Values extends any[],
     TagName extends ReorderElementTag = DefaultGroupElement
 >(
-    props: ReorderGroupProps<V, TagName> & { ref?: React.ForwardedRef<any> }
+    props: Omit<
+        ReorderGroupProps<Values[number], TagName>,
+        "values" | "onReorder"
+    > & {
+        values: Values
+        onReorder: (newOrder: Values) => void
+    } & { ref?: React.ForwardedRef<any> }
 ) => ReturnType<typeof ReorderGroupComponent>
 
 function compareMin<V>(a: ItemData<V>, b: ItemData<V>) {

--- a/packages/framer-motion/src/components/Reorder/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/components/Reorder/__tests__/index.test.tsx
@@ -1,9 +1,36 @@
-import { useContext, useLayoutEffect, useRef } from "react"
+import { useContext, useLayoutEffect, useRef, useState } from "react"
 import { Reorder } from ".."
 import { ReorderContext } from "../../../context/ReorderContext"
 import { render } from "../../../jest.setup"
 
 describe("Reorder", () => {
+    it("Accepts union array types for values prop", () => {
+        const Component = () => {
+            const [items, setItems] = useState<number[] | string[]>([
+                "a",
+                "b",
+                "c",
+            ])
+
+            return (
+                <Reorder.Group
+                    values={items}
+                    onReorder={setItems}
+                    axis="y"
+                >
+                    {items.map((item) => (
+                        <Reorder.Item key={item} value={item}>
+                            {item}
+                        </Reorder.Item>
+                    ))}
+                </Reorder.Group>
+            )
+        }
+
+        const { container } = render(<Component />)
+        expect(container.querySelectorAll("li")).toHaveLength(3)
+    })
+
     it("Correctly hydrates ref", () => {
         let groupRefPass = false
         let itemRefPass = false


### PR DESCRIPTION
## Summary

Fixes #2905

`Reorder.Group`'s `values` prop was typed as `V[]` with a single generic element type `V`, which prevented passing union array types like `number[] | string[]`. TypeScript would infer `V = number` from the first union member and then reject `string[]`.

**Cause:** The external type signature used `V` as the element type, so `values: V[]` couldn't represent `number[] | string[]` (a union of arrays is not the same as an array of unions).

**Fix:** Changed the external type assertion to be generic over the full array type (`Values extends any[]`) instead of just the element type. The `values` prop now accepts `Values` directly, and `onReorder` returns `Values`, so union array types flow through correctly. The internal implementation is unchanged — it derives the element type as `Values[number]` where needed.

This is a backwards-compatible change: existing code using `string[]`, `number[]`, or `MyObject[]` continues to work exactly as before.

## Test plan

- [x] Added unit test that uses `useState<number[] | string[]>` with `Reorder.Group` — verifies the TypeScript compilation and rendering
- [x] Existing Reorder tests pass (ref hydration, virtualized list reorder)
- [x] Full build passes (`yarn build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)