### PR TITLE
Fix layout animations not triggering with MotionValue

### DIFF
--- a/dev/react/src/tests/layout-motion-value.tsx
+++ b/dev/react/src/tests/layout-motion-value.tsx
@@ -1,0 +1,30 @@
+import { motion, useMotionValue } from "framer-motion"
+
+export const App = () => {
+    const width = useMotionValue(100)
+
+    return (
+        <>
+            <motion.div
+                id="box"
+                layout
+                style={{
+                    width,
+                    height: 100,
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    background: "red",
+                }}
+                transition={{ duration: 0.5, ease: () => 0.5 }}
+            />
+            <button
+                id="toggle"
+                style={{ position: "absolute", top: 200 }}
+                onClick={() => width.set(width.get() === 100 ? 300 : 100)}
+            >
+                Toggle
+            </button>
+        </>
+    )
+}

--- a/packages/framer-motion/cypress/integration/layout-motion-value.ts
+++ b/packages/framer-motion/cypress/integration/layout-motion-value.ts
@@ -1,0 +1,21 @@
+describe("Layout animation with MotionValue", () => {
+    it("Triggers layout animation when MotionValue changes a layout-affecting property", () => {
+        cy.visit("?test=layout-motion-value")
+            .wait(50)
+            .get("#box")
+            .should(([$box]: any) => {
+                const bbox = $box.getBoundingClientRect()
+                expect(bbox.width).to.equal(100)
+            })
+            .get("#toggle")
+            .trigger("click")
+            .wait(50)
+            .get("#box")
+            .should(([$box]: any) => {
+                const bbox = $box.getBoundingClientRect()
+                // With ease: () => 0.5, layout animation freezes at 50%
+                // Width should be 200 (midpoint of 100→300), not 300 (no animation)
+                expect(bbox.width).to.equal(200)
+            })
+    })
+})

--- a/packages/motion-dom/src/render/VisualElement.ts
+++ b/packages/motion-dom/src/render/VisualElement.ts
@@ -45,6 +45,15 @@ import {
 } from "./utils/reduced-motion"
 import { resolveVariantFromProps } from "./utils/resolve-variants"
 
+const layoutKeys = new Set([
+    "width",
+    "height",
+    "top",
+    "left",
+    "right",
+    "bottom",
+])
+
 const propEventHandlers = [
     "AnimationStart",
     "AnimationComplete",
@@ -567,6 +576,7 @@ export abstract class VisualElement<
         }
 
         const valueIsTransform = transformProps.has(key)
+        const valueIsLayout = !valueIsTransform && layoutKeys.has(key)
 
         if (valueIsTransform && this.onBindTransform) {
             this.onBindTransform()
@@ -579,8 +589,15 @@ export abstract class VisualElement<
 
                 this.props.onUpdate && frame.preRender(this.notifyUpdate)
 
-                if (valueIsTransform && this.projection) {
-                    this.projection.isTransformDirty = true
+                if (this.projection) {
+                    if (valueIsTransform) {
+                        this.projection.isTransformDirty = true
+                    } else if (valueIsLayout) {
+                        this.projection.willUpdate()
+                        frame.postRender(
+                            () => this.projection?.root?.didUpdate()
+                        )
+                    }
                 }
 
                 this.scheduleRender()


### PR DESCRIPTION
## Summary

Fixes #2907

Layout animations did not work when a `MotionValue` drove a layout-affecting style property (e.g. `width`, `height`). This happened because `MotionValue` updates bypass React's render cycle, so the projection system was never notified of the layout change — `willUpdate()` and `didUpdate()` were never called.

**Cause:** In `VisualElement.bindToMotionValue()`, the `onChange` handler only set `isTransformDirty` for transform properties. Non-transform positional properties (`width`, `height`, `top`, `left`, `right`, `bottom`) triggered a DOM render but never notified the projection system.

**Fix:** When a layout-affecting MotionValue changes, call `projection.willUpdate()` (to snapshot the old layout before render) and schedule `projection.root.didUpdate()` via `frame.postRender` (to measure the new layout and start the animation after the DOM updates).

## Test plan

- [x] Added Cypress E2E test (`layout-motion-value`) that verifies a `motion.div` with `layout` and a `useMotionValue`-driven `width` animates correctly when the value changes
- [x] Test fails without the fix (width snaps to 300 instead of animating)
- [x] Test passes with the fix on React 18
- [x] Test passes with the fix on React 19
- [x] All 774 existing unit tests pass (2 pre-existing flaky failures in `delay.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)