### PR TITLE
Fix scroll progress bar showing 100% with no overflow

### DIFF
--- a/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
@@ -398,6 +398,53 @@ describe("scrollInfo", () => {
         })
     })
 
+    test("Reports zero progress when container has no scroll overflow.", async () => {
+        let latest: ScrollInfo
+
+        const container = document.createElement("div")
+
+        const setContainerHeight = createMockMeasurement(
+            container,
+            "clientHeight"
+        )
+        const setContainerLength = createMockMeasurement(
+            container,
+            "scrollHeight"
+        )
+        const setContainerScrollTop = createMockMeasurement(
+            container,
+            "scrollTop"
+        )
+
+        // Content fits exactly in container — no overflow
+        setContainerHeight(500)
+        setContainerLength(500)
+
+        const fireElementScroll = async (distance: number = 0) => {
+            setContainerScrollTop(distance)
+            container.dispatchEvent(new window.Event("scroll"))
+            await nextFrame()
+        }
+
+        const stopScroll = scrollInfo(
+            (info) => {
+                latest = info
+            },
+            { container }
+        )
+
+        return new Promise<void>(async (resolve) => {
+            await fireElementScroll(0)
+
+            expect(latest.y.scrollLength).toEqual(0)
+            expect(latest.y.progress).toEqual(0)
+
+            stopScroll()
+
+            resolve()
+        })
+    })
+
     test("Reports non-negative progress for negative scroll values (reverse directions).", async () => {
         let latest: ScrollInfo
 

--- a/packages/framer-motion/src/render/dom/scroll/info.ts
+++ b/packages/framer-motion/src/render/dom/scroll/info.ts
@@ -52,7 +52,7 @@ function updateAxisInfo(
     axis.offset.length = 0
     axis.offset[0] = 0
     axis.offset[1] = axis.scrollLength
-    axis.progress = progress(0, axis.scrollLength, axis.current)
+    axis.progress = axis.scrollLength ? progress(0, axis.scrollLength, axis.current) : 0
 
     const elapsed = time - prevTime
     axis.velocity =


### PR DESCRIPTION
## Summary

- Fixes scroll progress immediately reporting 100% when a scroll container has no overflow (scrollHeight === clientHeight)
- The `progress()` utility returns `1` for a zero-width range (`progress(0, 0, 0) === 1`), which is correct for animations (zero-duration = complete) but wrong for scroll (no overflow = nothing scrolled)
- Added a guard in `updateAxisInfo` to return `0` progress when `scrollLength` is `0`

Fixes #2950

## Test plan

- [x] Added unit test: "Reports zero progress when container has no scroll overflow"
- [x] Verified test fails without the fix (`progress` returns `1` → 100%)
- [x] Verified test passes with the fix
- [x] All existing scroll tests pass (17/17)
- [x] Full `yarn test` passes
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)