### PR TITLE
Add E2E tests for SVG styles on mount

### DIFF
--- a/dev/react/src/tests/svg-style-on-mount.tsx
+++ b/dev/react/src/tests/svg-style-on-mount.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { motion, useMotionValue, useTransform } from "framer-motion"
+
+/**
+ * Test: SVG styles should apply correctly on mount when using useTransform.
+ * Reproduction for #2949: SVG transform-origin and styles not applying on mount.
+ *
+ * The bug: SVG elements with transforms derived from useTransform would have
+ * incorrect transformOrigin and transformBox on initial mount, causing a visible
+ * jump when the visual element takes over rendering.
+ */
+export function App() {
+    const x = useMotionValue(50)
+
+    // Derived transform values via useTransform
+    const pathLength = useTransform(x, [0, 100], [0, 1])
+    const opacity = useTransform(x, [0, 100], [0, 1])
+    const fill = useTransform(x, [0, 100], ["#0000ff", "#ff0000"])
+
+    return (
+        <svg width="200" height="200" data-testid="svg">
+            {/* Path with useTransform-derived pathLength + opacity + CSS transform */}
+            <motion.path
+                id="path"
+                d="M 10 80 C 40 10, 65 10, 95 80 S 150 150, 180 80"
+                fill="none"
+                stroke="black"
+                strokeWidth="2"
+                style={{ pathLength, opacity, x: 10, y: 10 }}
+            />
+            {/* Circle with useTransform-derived fill */}
+            <motion.circle
+                id="circle"
+                cx="100"
+                cy="100"
+                r="40"
+                fill={fill}
+            />
+            {/* Rect with static transform to test transformBox/transformOrigin */}
+            <motion.rect
+                id="rect"
+                x="10"
+                y="10"
+                width="50"
+                height="50"
+                style={{ rotate: 45 }}
+            />
+        </svg>
+    )
+}

--- a/packages/framer-motion/cypress/integration/svg-style-on-mount.ts
+++ b/packages/framer-motion/cypress/integration/svg-style-on-mount.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for #2949: SVG styles not applying on mount.
+ *
+ * The bug: SVG elements using useTransform-derived values would have
+ * incorrect transformOrigin/transformBox on initial mount (before
+ * dimensions are measured), causing a visible "jump" when the visual
+ * element takes over.
+ *
+ * The fix: Always set transformBox to "fill-box" and transformOrigin
+ * to "50% 50%" on SVG elements with transforms, even before dimensions
+ * are measured.
+ */
+describe("SVG styles on mount (#2949)", () => {
+    it("Applies transform, transformBox, and transformOrigin on mount", () => {
+        cy.visit("?test=svg-style-on-mount")
+            .get("#path")
+            .then(([$path]: any) => {
+                // Transform should be applied immediately on mount
+                expect($path.style.transform).to.contain("translateX(10px)")
+                expect($path.style.transform).to.contain("translateY(10px)")
+
+                // transformBox must be "fill-box" on initial mount
+                // (this was the core of the #2949 bug — it was missing)
+                expect($path.style.transformBox).to.equal("fill-box")
+
+                // transformOrigin must be set to prevent jumping
+                expect($path.style.transformOrigin).to.equal("50% 50%")
+            })
+    })
+
+    it("Applies useTransform-derived pathLength attributes on mount", () => {
+        cy.visit("?test=svg-style-on-mount")
+            .get("#path")
+            .then(([$path]: any) => {
+                // pathLength should be 0.5 (useTransform(50, [0,100], [0,1]))
+                // buildSVGPath normalizes the pathLength attribute to 1
+                expect($path.getAttribute("pathLength")).to.equal("1")
+
+                // stroke-dasharray should reflect pathLength=0.5
+                expect($path.getAttribute("stroke-dasharray")).to.equal(
+                    "0.5 1"
+                )
+
+                // stroke-dashoffset should be 0 (pathOffset defaults to 0)
+                const dashoffset = $path.getAttribute("stroke-dashoffset")
+                expect(parseFloat(dashoffset)).to.equal(0)
+            })
+    })
+
+    it("Applies useTransform-derived opacity on SVG path on mount", () => {
+        cy.visit("?test=svg-style-on-mount")
+            .get("#path")
+            .then(([$path]: any) => {
+                // opacity should be 0.5 (useTransform(50, [0,100], [0,1]))
+                const opacity =
+                    $path.getAttribute("opacity") ??
+                    window.getComputedStyle($path).opacity
+                expect(parseFloat(opacity)).to.equal(0.5)
+            })
+    })
+
+    it("Applies useTransform-derived fill on SVG circle on mount", () => {
+        cy.visit("?test=svg-style-on-mount")
+            .get("#circle")
+            .then(([$circle]: any) => {
+                // fill should be interpolated (not null/empty/default)
+                const fill = $circle.getAttribute("fill")
+                expect(fill).to.not.be.null
+                expect(fill).to.not.equal("")
+            })
+    })
+
+    it("Applies transformBox and transformOrigin on SVG rect with static transform", () => {
+        cy.visit("?test=svg-style-on-mount")
+            .get("#rect")
+            .then(([$rect]: any) => {
+                expect($rect.style.transform).to.equal("rotate(45deg)")
+                expect($rect.style.transformBox).to.equal("fill-box")
+                expect($rect.style.transformOrigin).to.equal("50% 50%")
+            })
+    })
+})


### PR DESCRIPTION
## Summary

- Adds Cypress E2E tests verifying SVG styles apply correctly on initial mount when using `useTransform`
- Tests cover: transform/transformBox/transformOrigin, pathLength/stroke-dasharray/stroke-dashoffset, opacity, and fill on SVG elements
- All tests pass on both React 18 and React 19

## Background

The bug reported in #2949 — SVG transform-origin jumping on initial mount because dimensions aren't measured yet — was already fixed in PR #3154 (merged April 2025). That PR ensured `transformBox: "fill-box"` and `transformOrigin: "50% 50%"` are set on SVG elements before dimensions are measured. The fix was preserved during the subsequent `motion-dom` refactoring.

However, the issue was never auto-closed because PR #3154 used `ref: #2949` instead of `Fixes #2949`. This PR adds targeted regression tests and closes the issue.

Fixes #2949

## Test plan

- [x] Cypress tests pass on React 18
- [x] Cypress tests pass on React 19
- [x] All 776 existing unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)