### PR TITLE
Fix useScroll target not accounting for CSS translate

### DIFF
--- a/dev/react/src/tests/scroll-target-translate.tsx
+++ b/dev/react/src/tests/scroll-target-translate.tsx
@@ -1,0 +1,42 @@
+import { motion, useScroll, useTransform } from "framer-motion"
+import * as React from "react"
+import { useRef } from "react"
+
+/**
+ * Regression test for #2914: useScroll target should account for CSS translate.
+ *
+ * The target div has transform: translateY(500px), pushing it 500px lower visually.
+ * Without the fix, useScroll ignores the translate and reports incorrect progress.
+ */
+export const App = () => {
+    const targetRef = useRef<HTMLDivElement>(null)
+    const { scrollYProgress } = useScroll({
+        target: targetRef,
+        offset: ["start end", "end start"],
+    })
+
+    // Drive opacity from scroll progress so Cypress can read computed style
+    const opacity = useTransform(scrollYProgress, [0, 1], [1, 0])
+
+    return (
+        <div>
+            <div style={{ height: 1000 }} />
+            <div
+                ref={targetRef}
+                id="target"
+                style={{
+                    height: 200,
+                    width: 200,
+                    background: "red",
+                    transform: "translateY(500px)",
+                }}
+            >
+                <motion.div
+                    id="indicator"
+                    style={{ width: 50, height: 50, background: "blue", opacity }}
+                />
+            </div>
+            <div style={{ height: 3000 }} />
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/scroll-target-translate.ts
+++ b/packages/framer-motion/cypress/integration/scroll-target-translate.ts
@@ -1,0 +1,26 @@
+describe("useScroll target accounts for CSS translate (#2914)", () => {
+    it("scroll progress reflects CSS translateY on target", () => {
+        cy.visit("?test=scroll-target-translate")
+            .wait(200)
+            .scrollTo(0, 1000, { duration: 0 })
+            .wait(500)
+            .get("#indicator")
+            .then(([$el]: any) => {
+                const opacity = parseFloat(getComputedStyle($el).opacity)
+                /**
+                 * Target layout position: 1000px (spacer height).
+                 * Target has transform: translateY(500px), visual position = 1500px.
+                 * With offset ["start end", "end start"] and 660px viewport:
+                 *
+                 * With fix (accounts for translate):
+                 *   progress at scroll 1000 ≈ 0.19, opacity ≈ 0.81
+                 *
+                 * Without fix (ignores translate):
+                 *   progress at scroll 1000 ≈ 0.77, opacity ≈ 0.23
+                 *
+                 * Assert opacity > 0.5 to verify translate is accounted for.
+                 */
+                expect(opacity).to.be.greaterThan(0.5)
+            })
+    })
+})

--- a/packages/framer-motion/src/render/dom/scroll/offsets/inset.ts
+++ b/packages/framer-motion/src/render/dom/scroll/offsets/inset.ts
@@ -1,5 +1,28 @@
 import { isHTMLElement } from "motion-dom"
 
+function addTranslateOffset(
+    inset: { x: number; y: number },
+    element: HTMLElement
+) {
+    const style = getComputedStyle(element)
+    const { translate, transform } = style
+
+    if (translate && translate !== "none") {
+        const parts = translate.split(" ")
+        inset.x += parseFloat(parts[0]) || 0
+        inset.y += parseFloat(parts[1] || "0") || 0
+    }
+
+    if (transform && transform !== "none") {
+        const match = transform.match(/matrix\(([^)]+)\)/)
+        if (match) {
+            const values = match[1].split(",")
+            inset.x += parseFloat(values[4])
+            inset.y += parseFloat(values[5])
+        }
+    }
+}
+
 export function calcInset(element: Element, container: Element) {
     const inset = { x: 0, y: 0 }
 
@@ -8,6 +31,7 @@ export function calcInset(element: Element, container: Element) {
         if (isHTMLElement(current)) {
             inset.x += current.offsetLeft
             inset.y += current.offsetTop
+            addTranslateOffset(inset, current)
             current = current.offsetParent
         } else if (current.tagName === "svg") {
             /**


### PR DESCRIPTION
## Summary

- `useScroll` with a `target` element now correctly accounts for CSS `translate` and `transform` translations when calculating scroll progress
- Previously, `calcInset()` used only `offsetLeft`/`offsetTop` which ignore CSS transforms, causing incorrect scroll progress when the target has a CSS translation
- Added `addTranslateOffset()` helper that reads the element's computed `translate` and `transform` styles, extracting translation offsets from the matrix

## How it works

For each element in the `offsetParent` chain, we now also read:
1. The CSS `translate` property (e.g., `translate: 100px 200px`)
2. The CSS `transform` property's resolved matrix (e.g., `matrix(1, 0, 0, 1, 0, 500)` from `transform: translateY(500px)`)

The translation components are added to the layout-based `offsetTop`/`offsetLeft` values, giving the correct visual position.

## Test plan

- [x] New Cypress E2E test (`scroll-target-translate`) verifies scroll progress accounts for `transform: translateY(500px)` on target
- [x] Existing `scroll-target-transform` test still passes
- [x] All 776 unit tests pass
- [x] Cypress tests pass on both React 18 and React 19

Fixes #2914

🤖 Generated with [Claude Code](https://claude.com/claude-code)