### PR TITLE
fix: revert string offset ViewTimeline acceleration

### DIFF
--- a/packages/framer-motion/src/render/dom/scroll/utils/__tests__/offset-to-range.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/utils/__tests__/offset-to-range.test.ts
@@ -56,52 +56,19 @@ describe("offsetToViewTimelineRange", () => {
         })
     })
 
-    it("returns Enter preset for string offsets", () => {
+    it("returns undefined for string offsets (not accelerated)", () => {
         expect(
             offsetToViewTimelineRange(["start end", "end end"])
-        ).toEqual({
-            rangeStart: "entry 0%",
-            rangeEnd: "entry 100%",
-        })
-    })
-
-    it("returns Exit preset for string offsets", () => {
+        ).toBeUndefined()
         expect(
             offsetToViewTimelineRange(["start start", "end start"])
-        ).toEqual({
-            rangeStart: "exit 0%",
-            rangeEnd: "exit 100%",
-        })
-    })
-
-    it("returns Any preset for string offsets", () => {
+        ).toBeUndefined()
         expect(
             offsetToViewTimelineRange(["end start", "start end"])
-        ).toEqual({
-            rangeStart: "cover 0%",
-            rangeEnd: "cover 100%",
-        })
-    })
-
-    it("returns All preset for string offsets", () => {
+        ).toBeUndefined()
         expect(
             offsetToViewTimelineRange(["start start", "end end"])
-        ).toEqual({
-            rangeStart: "contain 0%",
-            rangeEnd: "contain 100%",
-        })
-    })
-
-    it("returns All preset for string offsets", () => {
-        expect(
-            offsetToViewTimelineRange(["start start", "end end"])
-        ).toEqual({
-            rangeStart: "contain 0%",
-            rangeEnd: "contain 100%",
-        })
-    })
-
-    it("returns undefined for other string offsets", () => {
+        ).toBeUndefined()
         expect(
             offsetToViewTimelineRange(["start center", "end start"])
         ).toBeUndefined()

--- a/packages/framer-motion/src/render/dom/scroll/utils/offset-to-range.ts
+++ b/packages/framer-motion/src/render/dom/scroll/utils/offset-to-range.ts
@@ -18,32 +18,12 @@ const presets: [ProgressIntersection[], string][] = [
     [ScrollOffsetPresets.All, "contain"],
 ]
 
-const stringToProgress: Record<string, number> = {
-    start: 0,
-    end: 1,
-}
-
-function parseStringOffset(
-    s: string
-): ProgressIntersection | undefined {
-    const parts = s.trim().split(/\s+/)
-    if (parts.length !== 2) return undefined
-    const a = stringToProgress[parts[0]]
-    const b = stringToProgress[parts[1]]
-    if (a === undefined || b === undefined) return undefined
-    return [a, b]
-}
-
 function normaliseOffset(offset: ScrollOffset): ProgressIntersection[] | undefined {
     if (offset.length !== 2) return undefined
     const result: ProgressIntersection[] = []
     for (const item of offset) {
         if (Array.isArray(item)) {
             result.push(item as ProgressIntersection)
-        } else if (typeof item === "string") {
-            const parsed = parseStringOffset(item)
-            if (!parsed) return undefined
-            result.push(parsed)
         } else {
             return undefined
         }


### PR DESCRIPTION
## Problem

Since v12.37.0 (commit `6bae74e` — "Add string offset to ViewTimeline"), `useScroll` with string-based offsets such as `['start start', 'end end']` produces incorrect animation behaviour.

When a scroll-driven animation target uses `position: sticky` inside a `height: 200vh` container with a transformed parent, the ViewTimeline `"contain"` range does not produce identical results to the JS-based scroll tracking that was used before 12.37.0. Specifically:

- Some of the animation is already applied when the element first enters the viewport
- The animation does not reach completion when scrolling past

### Reproduction

See issue #3658 for a CodeSandbox reproduction and a video demonstrating the bug.

## Root Cause

The `parseStringOffset()` function added in `6bae74e` converts string offsets like `"start start"` to `ProgressIntersection` arrays, which enables `offsetToViewTimelineRange()` to return a ViewTimeline range (e.g. `"contain 0%" / "contain 100%"`). This causes `canAccelerateScroll()` in `use-scroll.ts` to return `true`, switching from JS main-thread scroll tracking to hardware-accelerated WAAPI animation.

The WAAPI ViewTimeline animation with `"contain"` range behaves differently from the JS-based scroll tracking for this DOM structure, producing the visual regression.

Notably, the existing Cypress E2E test in `scroll-view-timeline.ts` still asserts **"Does NOT accelerate target with string offset"**, which was never updated after 12.37.0 — confirming the acceleration of string offsets was not fully tested.

## Fix

This PR removes `parseStringOffset()` and the `stringToProgress` mapping from `offset-to-range.ts`, and makes `normaliseOffset()` return `undefined` for any non-array offset item. This restores the pre-12.37.0 behaviour where string offsets always fall back to JS main-thread scroll tracking.

Array-based `ProgressIntersection` offsets (the original preset format) continue to be accelerated as before — this change only affects string offsets.

### Changes

- **`offset-to-range.ts`**: Removed `parseStringOffset()`, `stringToProgress`, and string handling in `normaliseOffset()` (−20 lines)
- **`offset-to-range.test.ts`**: Updated string offset tests to expect `undefined` instead of range objects (+5/−58 lines)

All 37 existing unit tests pass (offset-to-range, use-scroll, use-transform).

Fixes #3658