### PR TITLE
Fix incorrect spring stiffness default in docs

### DIFF
--- a/packages/motion-dom/src/animation/types.ts
+++ b/packages/motion-dom/src/animation/types.ts
@@ -277,6 +277,8 @@ export interface SpringOptions extends DurationSpringOptions, VelocityOptions {
      * Stiffness of the spring. Higher values will create more sudden movement.
      * Set to `100` by default.
      *
+     * @default 100
+     *
      * @public
      */
     stiffness?: number
@@ -285,6 +287,8 @@ export interface SpringOptions extends DurationSpringOptions, VelocityOptions {
      * Strength of opposing force. If set to 0, spring will oscillate
      * indefinitely. Set to `10` by default.
      *
+     * @default 10
+     *
      * @public
      */
     damping?: number
@@ -292,6 +296,8 @@ export interface SpringOptions extends DurationSpringOptions, VelocityOptions {
     /**
      * Mass of the moving object. Higher values will result in more lethargic
      * movement. Set to `1` by default.
+     *
+     * @default 1
      *
      * @public
      */


### PR DESCRIPTION
## Summary
Fixes the incorrect default value shown for `stiffness` in the docs.

## Changes made
- Added explicit TSDoc `@default` values for spring options in `SpringOptions`
- Set `stiffness` to `100`
- Also documented `damping` as `10` and `mass` as `1`

## Notes
The docs appear to be generated from source metadata, and the runtime implementation already uses `stiffness: 100` in `springDefaults`.

## Issue
Closes #3664