### PR TITLE
fix(useAnimate): respect MotionConfig skipAnimations & apply final value

### DIFF
--- a/packages/framer-motion/src/animation/animate/index.ts
+++ b/packages/framer-motion/src/animation/animate/index.ts
@@ -25,6 +25,7 @@ function isSequence(value: unknown): value is AnimationSequence {
 interface ScopedAnimateOptions {
     scope?: AnimationScope
     reduceMotion?: boolean
+    skipAnimations?: boolean
 }
 
 /**
@@ -32,7 +33,7 @@ interface ScopedAnimateOptions {
  * to a specific element.
  */
 export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
-    const { scope, reduceMotion } = options
+    const { scope, reduceMotion, skipAnimations } = options
     /**
      * Animate a sequence
      */
@@ -117,9 +118,13 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
             }
             animations = animateSequence(
                 subjectOrSequence,
-                reduceMotion !== undefined
-                    ? { reduceMotion, ...sequenceOptions }
-                    : (sequenceOptions as SequenceOptions),
+                {
+                    ...(reduceMotion !== undefined ? { reduceMotion } : {}),
+                    ...(skipAnimations !== undefined
+                        ? { skipAnimations }
+                        : {}),
+                    ...sequenceOptions,
+                } as SequenceOptions,
                 scope
             )
         } else {
@@ -131,9 +136,13 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
             animations = animateSubject(
                 subjectOrSequence as ElementOrSelector,
                 optionsOrKeyframes as DOMKeyframesDefinition,
-                (reduceMotion !== undefined
-                    ? { reduceMotion, ...rest }
-                    : rest) as DynamicAnimationOptions,
+                {
+                    ...(reduceMotion !== undefined ? { reduceMotion } : {}),
+                    ...(skipAnimations !== undefined
+                        ? { skipAnimations }
+                        : {}),
+                    ...rest,
+                } as DynamicAnimationOptions,
                 scope
             )
         }

--- a/packages/framer-motion/src/animation/animate/index.ts
+++ b/packages/framer-motion/src/animation/animate/index.ts
@@ -110,6 +110,12 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
         let animations: AnimationPlaybackControlsWithThen[] = []
         let animationOnComplete: VoidFunction | undefined
 
+        const inherited: { reduceMotion?: boolean; skipAnimations?: boolean } =
+            {}
+        if (reduceMotion !== undefined) inherited.reduceMotion = reduceMotion
+        if (skipAnimations !== undefined)
+            inherited.skipAnimations = skipAnimations
+
         if (isSequence(subjectOrSequence)) {
             const { onComplete, ...sequenceOptions } =
                 (optionsOrKeyframes as SequenceOptions) || {}
@@ -118,13 +124,7 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
             }
             animations = animateSequence(
                 subjectOrSequence,
-                {
-                    ...(reduceMotion !== undefined ? { reduceMotion } : {}),
-                    ...(skipAnimations !== undefined
-                        ? { skipAnimations }
-                        : {}),
-                    ...sequenceOptions,
-                } as SequenceOptions,
+                { ...inherited, ...sequenceOptions } as SequenceOptions,
                 scope
             )
         } else {
@@ -136,13 +136,7 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
             animations = animateSubject(
                 subjectOrSequence as ElementOrSelector,
                 optionsOrKeyframes as DOMKeyframesDefinition,
-                {
-                    ...(reduceMotion !== undefined ? { reduceMotion } : {}),
-                    ...(skipAnimations !== undefined
-                        ? { skipAnimations }
-                        : {}),
-                    ...rest,
-                } as DynamicAnimationOptions,
+                { ...inherited, ...rest } as DynamicAnimationOptions,
                 scope
             )
         }

--- a/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
+++ b/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
@@ -130,8 +130,6 @@ describe("useAnimate", () => {
                     )
 
                     setTimeout(() => {
-                        // Animation should have been skipped to its final
-                        // value, not allowed to run for 10s.
                         expect(scope.current).toHaveStyle("opacity: 0.5;")
                         expect(scope.animations.length).toBe(0)
                         resolve()

--- a/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
+++ b/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom"
 import { render } from "@testing-library/react"
 import { useEffect } from "react"
+import { MotionConfig } from "../../../components/MotionConfig"
 import { useAnimate } from "../use-animate"
 
 describe("useAnimate", () => {
@@ -114,5 +115,37 @@ describe("useAnimate", () => {
         })
 
         expect(frameCount).toEqual(3)
+    })
+
+    test("Applies final value instantly when MotionConfig skipAnimations is true", () => {
+        return new Promise<void>((resolve) => {
+            const Component = () => {
+                const [scope, animate] = useAnimate()
+
+                useEffect(() => {
+                    animate(
+                        scope.current,
+                        { opacity: 0.5 },
+                        { duration: 10 }
+                    )
+
+                    setTimeout(() => {
+                        // Animation should have been skipped to its final
+                        // value, not allowed to run for 10s.
+                        expect(scope.current).toHaveStyle("opacity: 0.5;")
+                        expect(scope.animations.length).toBe(0)
+                        resolve()
+                    }, 50)
+                })
+
+                return <div ref={scope} />
+            }
+
+            render(
+                <MotionConfig skipAnimations>
+                    <Component />
+                </MotionConfig>
+            )
+        })
     })
 })

--- a/packages/framer-motion/src/animation/hooks/use-animate.ts
+++ b/packages/framer-motion/src/animation/hooks/use-animate.ts
@@ -1,10 +1,11 @@
 "use client"
 
-import { useMemo } from "react"
+import { useContext, useMemo } from "react"
 import { AnimationScope } from "motion-dom"
 import { useConstant } from "../../utils/use-constant"
 import { useUnmountEffect } from "../../utils/use-unmount-effect"
 import { useReducedMotionConfig } from "../../utils/reduced-motion/use-reduced-motion-config"
+import { MotionConfigContext } from "../../context/MotionConfigContext"
 import { createScopedAnimate } from "../animate"
 
 export function useAnimate<T extends Element = any>() {
@@ -14,10 +15,11 @@ export function useAnimate<T extends Element = any>() {
     }))
 
     const reduceMotion = useReducedMotionConfig() ?? undefined
+    const { skipAnimations } = useContext(MotionConfigContext)
 
     const animate = useMemo(
-        () => createScopedAnimate({ scope, reduceMotion }),
-        [scope, reduceMotion]
+        () => createScopedAnimate({ scope, reduceMotion, skipAnimations }),
+        [scope, reduceMotion, skipAnimations]
     )
 
     useUnmountEffect(() => {

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -118,6 +118,7 @@ export interface SequenceOptions extends AnimationPlaybackOptions {
     duration?: number
     defaultTransition?: Transition
     reduceMotion?: boolean
+    skipAnimations?: boolean
     onComplete?: () => void
 }
 

--- a/packages/motion-dom/src/animation/interfaces/motion-value.ts
+++ b/packages/motion-dom/src/animation/interfaces/motion-value.ts
@@ -100,7 +100,8 @@ export const animateMotionValue =
         if (
             MotionGlobalConfig.instantAnimations ||
             MotionGlobalConfig.skipAnimations ||
-            element?.shouldSkipAnimations
+            element?.shouldSkipAnimations ||
+            valueTransition.skipAnimations
         ) {
             shouldSkip = true
             makeAnimationInstant(options)

--- a/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
+++ b/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
@@ -46,8 +46,7 @@ export function animateTarget(
         : defaultTransition
 
     const reduceMotion = (transition as { reduceMotion?: boolean })?.reduceMotion
-    const skipAnimations = (transition as { skipAnimations?: boolean })
-        ?.skipAnimations
+    const skipAnimations = transition?.skipAnimations
 
     if (transitionOverride) transition = transitionOverride
 

--- a/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
+++ b/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
@@ -46,6 +46,8 @@ export function animateTarget(
         : defaultTransition
 
     const reduceMotion = (transition as { reduceMotion?: boolean })?.reduceMotion
+    const skipAnimations = (transition as { skipAnimations?: boolean })
+        ?.skipAnimations
 
     if (transitionOverride) transition = transitionOverride
 
@@ -75,6 +77,8 @@ export function animateTarget(
             delay,
             ...getValueTransition(transition || {}, key),
         }
+
+        if (skipAnimations) valueTransition.skipAnimations = true
 
         /**
          * If the value is already at the defined target, skip the animation.

--- a/packages/motion-dom/src/animation/types.ts
+++ b/packages/motion-dom/src/animation/types.ts
@@ -479,6 +479,13 @@ export interface ValueTransition
      * @public
      */
     inherit?: boolean
+
+    /**
+     * If true, the animation skips straight to its final value instead of
+     * tweening. Used by `MotionConfig`'s `skipAnimations` to opt entire
+     * subtrees out of animation (e.g. for E2E screenshot stability).
+     */
+    skipAnimations?: boolean
 }
 
 /**

--- a/packages/motion-dom/src/animation/types.ts
+++ b/packages/motion-dom/src/animation/types.ts
@@ -484,6 +484,8 @@ export interface ValueTransition
      * If true, the animation skips straight to its final value instead of
      * tweening. Used by `MotionConfig`'s `skipAnimations` to opt entire
      * subtrees out of animation (e.g. for E2E screenshot stability).
+     *
+     * @public
      */
     skipAnimations?: boolean
 }


### PR DESCRIPTION
## Summary

`useAnimate`'s imperative `animate()` ignored `<MotionConfig skipAnimations>`, so WAAPI animations were still created in subtrees opted out of motion. WebKit reports those zero-duration animations as running, which causes Playwright's `element.getAnimations()` stability checks to time out indefinitely — even though the app explicitly opted out via `<MotionConfig skipAnimations>`.

This threads `skipAnimations` through `createScopedAnimate` the same way `reduceMotion` is threaded:

- `useAnimate` reads `MotionConfigContext.skipAnimations` and passes it to the scoped animate.
- `createScopedAnimate` forwards it onto the transition for each animated subject.
- `animateTarget` propagates it onto each per-key `valueTransition`.
- `animateMotionValue` treats `valueTransition.skipAnimations` as another trigger for the existing instant-final-keyframe path — alongside `MotionGlobalConfig.skipAnimations` and `element.shouldSkipAnimations`.

The result: no `JSAnimation` / `AsyncMotionValueAnimation` is ever constructed (so no WAAPI animation registers as running), and the final value is applied instantly via `frame.update`.

## Why this approach (vs. #3680)

#3680 fixed the same bug by replacing the animate function with a no-op (`new GroupAnimationWithThen([])`). That prevented WAAPI animations but also discarded target values entirely, leaving elements frozen in their starting state. That's inconsistent with every other skip path in the library:

- Declarative `<MotionConfig skipAnimations>` — `MotionConfig/__tests__/index.test.tsx:80-107` asserts motion values jump to their final keyframe.
- `MotionGlobalConfig.skipAnimations` — `animate/__tests__/animate.test.tsx:267-278` asserts `div` ends up with `opacity: 0.5` after `animate(div, { opacity: [0.2, 0.5] })`.
- The engine itself — `motion-dom/src/animation/interfaces/motion-value.ts` calls `makeAnimationInstant` and applies the final keyframe via `onUpdate(finalKeyframe)`.

This PR aligns `useAnimate` with that contract: skip the animation, apply the final value.

## Test

Added `useAnimate › Applies final value instantly when MotionConfig skipAnimations is true`. Uses `duration: 10` and asserts after 50ms — without the fix the value is at ~0.003 (mid-tween); with the fix it is `0.5` (instant). Also asserts `scope.animations.length === 0`.

Closes #3679. Supersedes #3680.

## Test plan

- [x] `npx jest --config jest.config.json` (framer-motion) — 778 passed, 10 skipped
- [x] `npx jest --config jest.config.json` (motion-dom) — 455 passed, 3 skipped
- [x] New `useAnimate` test passes 5/5 reruns
- [x] No new lint errors introduced