### PR TITLE
Fix useScroll inner motion components bound to wrong timeline

### DIFF
--- a/dev/react/src/tests/scroll-view-timeline-transformed-parent.tsx
+++ b/dev/react/src/tests/scroll-view-timeline-transformed-parent.tsx
@@ -1,24 +1,16 @@
-/**
- * Reproduction of #3658 (literal port of reporter's repro).
- *
- * The bug: nested motion components inside a useScroll target end up bound
- * to a generic ScrollTimeline (cover-range default) instead of the intended
- * ViewTimeline, because their bindToMotionValue runs before the outer
- * target ref has been attached.
- *
- * Surfaces:
- *  - #opacity-probe: motion.div whose opacity = scrollYProgress (0→1).
- *    Reading getComputedStyle(opacity) reflects what the compositor (WAAPI)
- *    is drawing — independent of the JS-driven motion value.
- *  - #js-progress: a second scroll() with a 2-arg callback, which always
- *    takes the JS scrollInfo path. Provides the expected layout-based
- *    progress to compare against.
- */
-import { motion, scroll, useScroll, useTransform } from "framer-motion"
+// Repro for #3658: nested motion components inside a useScroll target bind
+// to ScrollTimeline (cover defaults) instead of ViewTimeline.
+import { motion, MotionValue, scroll, useScroll, useTransform } from "framer-motion"
 import * as React from "react"
 import { useEffect, useRef } from "react"
 
-const FullRangeProbe = ({ progress }: { progress: any }) => {
+const heroStyle: React.CSSProperties = {
+    height: "100vh",
+    display: "grid",
+    placeItems: "center",
+}
+
+const FullRangeProbe = ({ progress }: { progress: MotionValue<number> }) => {
     const opacity = useTransform(progress, [0, 1], [0, 1])
     return (
         <motion.div
@@ -35,24 +27,23 @@ const FullRangeProbe = ({ progress }: { progress: any }) => {
 
 const TextReveal = ({ text }: { text: string }) => {
     const ref = useRef<HTMLDivElement>(null)
+    const jsRef = useRef<HTMLSpanElement>(null)
     const { scrollYProgress } = useScroll({
         target: ref,
         offset: ["start start", "end end"],
     })
 
-    const jsRef = useRef<HTMLSpanElement>(null)
-
     useEffect(() => {
         if (!ref.current) return
         // 2-arg callback forces the JS scrollInfo path (see attach-function.ts).
         return scroll(
-            (_progress: number, info: any) => {
+            (_progress, info) => {
                 if (jsRef.current)
                     jsRef.current.innerText = info.y.progress.toFixed(4)
             },
             {
                 target: ref.current,
-                offset: ["start start", "end end"] as any,
+                offset: ["start start", "end end"],
             }
         )
     }, [])
@@ -73,17 +64,13 @@ const TextReveal = ({ text }: { text: string }) => {
             >
                 <div
                     style={{
-                        display: "flex",
-                        gap: 16,
                         fontFamily: "monospace",
                         fontSize: 18,
                     }}
                 >
-                    <span>
-                        js:{" "}
-                        <span id="js-progress" ref={jsRef}>
-                            0
-                        </span>
+                    js:{" "}
+                    <span id="js-progress" ref={jsRef}>
+                        0
                     </span>
                 </div>
                 <FullRangeProbe progress={scrollYProgress} />
@@ -141,16 +128,9 @@ const ClipReveal = ({ children }: { children: React.ReactNode }) => {
 export const App = () => {
     return (
         <div style={{ background: "#111", color: "#fff", minHeight: "100vh" }}>
-            <div
-                style={{
-                    height: "100vh",
-                    display: "grid",
-                    placeItems: "center",
-                }}
-            >
+            <div style={heroStyle}>
                 <h1>Scroll down ↓</h1>
             </div>
-
             <ClipReveal>
                 <section
                     style={{
@@ -162,14 +142,7 @@ export const App = () => {
                     <TextReveal text="Building digital experiences that blur the line between imagination and reality." />
                 </section>
             </ClipReveal>
-
-            <div
-                style={{
-                    height: "100vh",
-                    display: "grid",
-                    placeItems: "center",
-                }}
-            >
+            <div style={heroStyle}>
                 <h1>End</h1>
             </div>
         </div>

--- a/dev/react/src/tests/scroll-view-timeline-transformed-parent.tsx
+++ b/dev/react/src/tests/scroll-view-timeline-transformed-parent.tsx
@@ -1,0 +1,177 @@
+/**
+ * Reproduction of #3658 (literal port of reporter's repro).
+ *
+ * The bug: nested motion components inside a useScroll target end up bound
+ * to a generic ScrollTimeline (cover-range default) instead of the intended
+ * ViewTimeline, because their bindToMotionValue runs before the outer
+ * target ref has been attached.
+ *
+ * Surfaces:
+ *  - #opacity-probe: motion.div whose opacity = scrollYProgress (0→1).
+ *    Reading getComputedStyle(opacity) reflects what the compositor (WAAPI)
+ *    is drawing — independent of the JS-driven motion value.
+ *  - #js-progress: a second scroll() with a 2-arg callback, which always
+ *    takes the JS scrollInfo path. Provides the expected layout-based
+ *    progress to compare against.
+ */
+import { motion, scroll, useScroll, useTransform } from "framer-motion"
+import * as React from "react"
+import { useEffect, useRef } from "react"
+
+const FullRangeProbe = ({ progress }: { progress: any }) => {
+    const opacity = useTransform(progress, [0, 1], [0, 1])
+    return (
+        <motion.div
+            id="opacity-probe"
+            style={{
+                width: 40,
+                height: 40,
+                background: "magenta",
+                opacity,
+            }}
+        />
+    )
+}
+
+const TextReveal = ({ text }: { text: string }) => {
+    const ref = useRef<HTMLDivElement>(null)
+    const { scrollYProgress } = useScroll({
+        target: ref,
+        offset: ["start start", "end end"],
+    })
+
+    const jsRef = useRef<HTMLSpanElement>(null)
+
+    useEffect(() => {
+        if (!ref.current) return
+        // 2-arg callback forces the JS scrollInfo path (see attach-function.ts).
+        return scroll(
+            (_progress: number, info: any) => {
+                if (jsRef.current)
+                    jsRef.current.innerText = info.y.progress.toFixed(4)
+            },
+            {
+                target: ref.current,
+                offset: ["start start", "end end"] as any,
+            }
+        )
+    }, [])
+
+    const words = text.split(" ")
+    return (
+        <div ref={ref} style={{ position: "relative", height: "200vh" }}>
+            <div
+                style={{
+                    position: "sticky",
+                    top: 0,
+                    height: "50%",
+                    display: "flex",
+                    alignItems: "center",
+                    flexDirection: "column",
+                    gap: 16,
+                }}
+            >
+                <div
+                    style={{
+                        display: "flex",
+                        gap: 16,
+                        fontFamily: "monospace",
+                        fontSize: 18,
+                    }}
+                >
+                    <span>
+                        js:{" "}
+                        <span id="js-progress" ref={jsRef}>
+                            0
+                        </span>
+                    </span>
+                </div>
+                <FullRangeProbe progress={scrollYProgress} />
+                <p
+                    style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: 8,
+                        fontSize: 32,
+                    }}
+                >
+                    {words.map((word, i) => {
+                        const start = i / words.length
+                        const end = start + 1 / words.length
+                        const opacity = useTransform(
+                            scrollYProgress,
+                            [start, end],
+                            [0.2, 1]
+                        )
+                        return (
+                            <motion.span
+                                key={i}
+                                style={{ opacity, color: "cyan" }}
+                            >
+                                {word}
+                            </motion.span>
+                        )
+                    })}
+                </p>
+            </div>
+        </div>
+    )
+}
+
+const ClipReveal = ({ children }: { children: React.ReactNode }) => {
+    const ref = useRef<HTMLDivElement>(null)
+    const { scrollYProgress } = useScroll({
+        target: ref,
+        offset: ["start end", "start 0.3"],
+    })
+    const clipPath = useTransform(
+        scrollYProgress,
+        [0, 1],
+        ["inset(8% 12% round 24px)", "inset(0% 0% round 0px)"]
+    )
+    const scale = useTransform(scrollYProgress, [0, 1], [0.95, 1])
+
+    return (
+        <div ref={ref}>
+            <motion.div style={{ clipPath, scale }}>{children}</motion.div>
+        </div>
+    )
+}
+
+export const App = () => {
+    return (
+        <div style={{ background: "#111", color: "#fff", minHeight: "100vh" }}>
+            <div
+                style={{
+                    height: "100vh",
+                    display: "grid",
+                    placeItems: "center",
+                }}
+            >
+                <h1>Scroll down ↓</h1>
+            </div>
+
+            <ClipReveal>
+                <section
+                    style={{
+                        background: "#000",
+                        minHeight: "50vh",
+                        paddingTop: 40,
+                    }}
+                >
+                    <TextReveal text="Building digital experiences that blur the line between imagination and reality." />
+                </section>
+            </ClipReveal>
+
+            <div
+                style={{
+                    height: "100vh",
+                    display: "grid",
+                    placeItems: "center",
+                }}
+            >
+                <h1>End</h1>
+            </div>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/scroll-view-timeline-transformed-parent.ts
+++ b/packages/framer-motion/cypress/integration/scroll-view-timeline-transformed-parent.ts
@@ -1,5 +1,6 @@
-// Regression for #3658. Run via `--browser chrome`; Electron's
-// WAAPI/ViewTimeline implementation differs from production Chrome.
+// Regression for #3658. The ViewTimeline assertion only runs in browsers
+// that support ViewTimeline — CI's Electron does not, so it falls back
+// to the JS path and there's nothing to assert against.
 
 const scrollToPx = (px: number) =>
     cy.window().then((win) => win.scrollTo(0, px))
@@ -13,15 +14,18 @@ const readJs = () =>
     cy.get("#js-progress").then(([$el]: any) => parseFloat($el.innerText))
 
 describe("useScroll + transformed ancestor (regression for #3658)", () => {
-    it("attaches ViewTimeline (not ScrollTimeline) to inner motion components", () => {
+    it("attaches ViewTimeline (not ScrollTimeline) to inner motion components", function () {
         cy.visit("?test=scroll-view-timeline-transformed-parent").wait(500)
-        cy.get("#opacity-probe").then(([$el]: any) => {
-            const anims = $el.getAnimations()
-            expect(anims).to.have.length.greaterThan(0)
-            const a = anims[0]
-            expect(a.timeline?.constructor?.name).to.equal("ViewTimeline")
-            expect(a.rangeStart?.rangeName).to.equal("contain")
-            expect(a.rangeEnd?.rangeName).to.equal("contain")
+        cy.window().then((win) => {
+            if (!(win as any).ViewTimeline) return this.skip()
+            cy.get("#opacity-probe").then(([$el]: any) => {
+                const anims = $el.getAnimations()
+                expect(anims).to.have.length.greaterThan(0)
+                const a = anims[0]
+                expect(a.timeline?.constructor?.name).to.equal("ViewTimeline")
+                expect(a.rangeStart?.rangeName).to.equal("contain")
+                expect(a.rangeEnd?.rangeName).to.equal("contain")
+            })
         })
     })
 

--- a/packages/framer-motion/cypress/integration/scroll-view-timeline-transformed-parent.ts
+++ b/packages/framer-motion/cypress/integration/scroll-view-timeline-transformed-parent.ts
@@ -1,31 +1,14 @@
-/**
- * Regression test for #3658.
- *
- * Two identical 200vh targets side-by-side, both using
- * useScroll({ offset: ["start start", "end end"] }). The right one is
- * wrapped in a motion.div with scale: 0.95.
- *
- * Layout positions are identical for both targets (transforms don't affect
- * layout), so scrollYProgress must match at every scroll position. If the
- * WAAPI ViewTimeline path is sensitive to ancestor transforms, "scaled"
- * will diverge from "plain".
- *
- * Use real Chrome (`--browser chrome`) — Electron's WAAPI/ViewTimeline
- * implementation differs.
- */
-
-const readProgress = (id: string) =>
-    cy.get(`#${id}-progress`).then(([$el]: any) => parseFloat($el.innerText))
+// Regression for #3658. Run via `--browser chrome`; Electron's
+// WAAPI/ViewTimeline implementation differs from production Chrome.
 
 const scrollToPx = (px: number) =>
-    cy.window().then((win) => {
-        win.scrollTo(0, px)
-    })
+    cy.window().then((win) => win.scrollTo(0, px))
 
 const readWaapi = () =>
     cy
         .get("#opacity-probe")
         .then(([$el]: any) => parseFloat(getComputedStyle($el).opacity))
+
 const readJs = () =>
     cy.get("#js-progress").then(([$el]: any) => parseFloat($el.innerText))
 
@@ -34,20 +17,11 @@ describe("useScroll + transformed ancestor (regression for #3658)", () => {
         cy.visit("?test=scroll-view-timeline-transformed-parent").wait(500)
         cy.get("#opacity-probe").then(([$el]: any) => {
             const anims = $el.getAnimations()
-            expect(
-                anims.length,
-                "opacity-probe should have a WAAPI animation"
-            ).to.be.greaterThan(0)
+            expect(anims).to.have.length.greaterThan(0)
             const a = anims[0]
             expect(a.timeline?.constructor?.name).to.equal("ViewTimeline")
-            // rangeStart/rangeEnd are TimelineRangeOffset objects in Chrome
-            // ({ rangeName, offset }). Coerce both shapes to a comparable string.
-            const stringify = (r: any) =>
-                r && typeof r === "object" && "rangeName" in r
-                    ? `${r.rangeName} ${r.offset?.value ?? r.offset}${r.offset?.unit ?? ""}`
-                    : String(r)
-            expect(stringify(a.rangeStart)).to.match(/contain/)
-            expect(stringify(a.rangeEnd)).to.match(/contain/)
+            expect(a.rangeStart?.rangeName).to.equal("contain")
+            expect(a.rangeEnd?.rangeName).to.equal("contain")
         })
     })
 
@@ -56,34 +30,19 @@ describe("useScroll + transformed ancestor (regression for #3658)", () => {
 
         cy.window().then((win) => {
             const vh = win.innerHeight
-            const stops: Array<{ label: string; y: number }> = [
-                { label: "before", y: 0.5 * vh },
-                { label: "enter", y: vh },
-                { label: "25%", y: vh + 0.25 * vh },
-                { label: "50%", y: vh + 0.5 * vh },
-                { label: "75%", y: vh + 0.75 * vh },
-                { label: "exit", y: 2 * vh },
-            ]
-            const lines: string[] = []
+            const stops = [0.5, 1, 1.25, 1.5, 1.75, 2].map((m) => m * vh)
             const drift: number[] = []
 
             cy.wrap(stops)
-                .each((stop: any) => {
-                    scrollToPx(stop.y)
+                .each((y: number) => {
+                    scrollToPx(y)
                     cy.wait(200)
                     readWaapi().then((w) => {
-                        readJs().then((j) => {
-                            lines.push(
-                                `[${stop.label}] y=${stop.y} waapi=${w.toFixed(4)} js=${j.toFixed(4)}`
-                            )
-                            drift.push(Math.abs(w - j))
-                        })
+                        readJs().then((j) => drift.push(Math.abs(w - j)))
                     })
                 })
                 .then(() => {
-                    const maxDrift = Math.max(...drift)
-                    const summary = lines.join(" | ")
-                    expect(maxDrift, summary).to.be.lessThan(0.01)
+                    expect(Math.max(...drift)).to.be.lessThan(0.01)
                 })
         })
     })

--- a/packages/framer-motion/cypress/integration/scroll-view-timeline-transformed-parent.ts
+++ b/packages/framer-motion/cypress/integration/scroll-view-timeline-transformed-parent.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for #3658.
+ *
+ * Two identical 200vh targets side-by-side, both using
+ * useScroll({ offset: ["start start", "end end"] }). The right one is
+ * wrapped in a motion.div with scale: 0.95.
+ *
+ * Layout positions are identical for both targets (transforms don't affect
+ * layout), so scrollYProgress must match at every scroll position. If the
+ * WAAPI ViewTimeline path is sensitive to ancestor transforms, "scaled"
+ * will diverge from "plain".
+ *
+ * Use real Chrome (`--browser chrome`) — Electron's WAAPI/ViewTimeline
+ * implementation differs.
+ */
+
+const readProgress = (id: string) =>
+    cy.get(`#${id}-progress`).then(([$el]: any) => parseFloat($el.innerText))
+
+const scrollToPx = (px: number) =>
+    cy.window().then((win) => {
+        win.scrollTo(0, px)
+    })
+
+const readWaapi = () =>
+    cy
+        .get("#opacity-probe")
+        .then(([$el]: any) => parseFloat(getComputedStyle($el).opacity))
+const readJs = () =>
+    cy.get("#js-progress").then(([$el]: any) => parseFloat($el.innerText))
+
+describe("useScroll + transformed ancestor (regression for #3658)", () => {
+    it("attaches ViewTimeline (not ScrollTimeline) to inner motion components", () => {
+        cy.visit("?test=scroll-view-timeline-transformed-parent").wait(500)
+        cy.get("#opacity-probe").then(([$el]: any) => {
+            const anims = $el.getAnimations()
+            expect(
+                anims.length,
+                "opacity-probe should have a WAAPI animation"
+            ).to.be.greaterThan(0)
+            const a = anims[0]
+            expect(a.timeline?.constructor?.name).to.equal("ViewTimeline")
+            // rangeStart/rangeEnd are TimelineRangeOffset objects in Chrome
+            // ({ rangeName, offset }). Coerce both shapes to a comparable string.
+            const stringify = (r: any) =>
+                r && typeof r === "object" && "rangeName" in r
+                    ? `${r.rangeName} ${r.offset?.value ?? r.offset}${r.offset?.unit ?? ""}`
+                    : String(r)
+            expect(stringify(a.rangeStart)).to.match(/contain/)
+            expect(stringify(a.rangeEnd)).to.match(/contain/)
+        })
+    })
+
+    it("WAAPI and JS paths agree on the same target across the scroll range", () => {
+        cy.visit("?test=scroll-view-timeline-transformed-parent").wait(500)
+
+        cy.window().then((win) => {
+            const vh = win.innerHeight
+            const stops: Array<{ label: string; y: number }> = [
+                { label: "before", y: 0.5 * vh },
+                { label: "enter", y: vh },
+                { label: "25%", y: vh + 0.25 * vh },
+                { label: "50%", y: vh + 0.5 * vh },
+                { label: "75%", y: vh + 0.75 * vh },
+                { label: "exit", y: 2 * vh },
+            ]
+            const lines: string[] = []
+            const drift: number[] = []
+
+            cy.wrap(stops)
+                .each((stop: any) => {
+                    scrollToPx(stop.y)
+                    cy.wait(200)
+                    readWaapi().then((w) => {
+                        readJs().then((j) => {
+                            lines.push(
+                                `[${stop.label}] y=${stop.y} waapi=${w.toFixed(4)} js=${j.toFixed(4)}`
+                            )
+                            drift.push(Math.abs(w - j))
+                        })
+                    })
+                })
+                .then(() => {
+                    const maxDrift = Math.max(...drift)
+                    const summary = lines.join(" | ")
+                    expect(maxDrift, summary).to.be.lessThan(0.01)
+                })
+        })
+    })
+})

--- a/packages/framer-motion/src/motion/utils/use-motion-ref.ts
+++ b/packages/framer-motion/src/motion/utils/use-motion-ref.ts
@@ -35,15 +35,8 @@ export function useMotionRef<Instance, RenderState>(
                 visualState.onMount?.(instance)
             }
 
-            /**
-             * Register the instance with the VisualElement before invoking
-             * the external ref so that consumer ref callbacks can resolve
-             * the VisualElement via visualElementStore.get(instance).
-             * mount() (which runs bindToMotionValue and depends on the
-             * external ref being populated) is deferred until after.
-             */
-            if (visualElement && instance) {
-                visualElement.register(instance)
+            if (visualElement) {
+                instance ? visualElement.mount(instance) : visualElement.unmount()
             }
 
             const ref = externalRefContainer.current
@@ -61,10 +54,6 @@ export function useMotionRef<Instance, RenderState>(
                 }
             } else if (ref) {
                 ;(ref as React.MutableRefObject<Instance>).current = instance
-            }
-
-            if (visualElement) {
-                instance ? visualElement.mount(instance) : visualElement.unmount()
             }
         },
         [visualElement]

--- a/packages/framer-motion/src/value/use-scroll.ts
+++ b/packages/framer-motion/src/value/use-scroll.ts
@@ -2,6 +2,8 @@
 
 import {
     AnimationPlaybackControls,
+    cancelMicrotask,
+    microtask,
     motionValue,
     supportsScrollTimeline,
     supportsViewTimeline,
@@ -39,23 +41,21 @@ function makeAccelerateConfig(
     target?: RefObject<HTMLElement | null>
 ) {
     return {
-        // Refs attach child-first; bindings nested inside the target would read
-        // a null target.current and fall back to ScrollTimeline. Defer one
-        // microtask so target.current is populated before getTimeline reads it.
+        // Refs attach child-first; defer so target.current is populated
+        // before scroll() reads it.
         factory: (animation: AnimationPlaybackControls) => {
             let cleanup: VoidFunction | undefined
-            let cancelled = false
-            queueMicrotask(() => {
-                if (cancelled) return
+            const start = () => {
                 cleanup = scroll(animation, {
                     ...options,
                     axis,
                     container: container?.current || undefined,
                     target: target?.current || undefined,
                 })
-            })
+            }
+            microtask.read(start)
             return () => {
-                cancelled = true
+                cancelMicrotask(start)
                 cleanup?.()
             }
         },

--- a/packages/framer-motion/src/value/use-scroll.ts
+++ b/packages/framer-motion/src/value/use-scroll.ts
@@ -39,13 +39,26 @@ function makeAccelerateConfig(
     target?: RefObject<HTMLElement | null>
 ) {
     return {
-        factory: (animation: AnimationPlaybackControls) =>
-            scroll(animation, {
-                ...options,
-                axis,
-                container: container?.current || undefined,
-                target: target?.current || undefined,
-            }),
+        // Refs attach child-first; bindings nested inside the target would read
+        // a null target.current and fall back to ScrollTimeline. Defer one
+        // microtask so target.current is populated before getTimeline reads it.
+        factory: (animation: AnimationPlaybackControls) => {
+            let cleanup: VoidFunction | undefined
+            let cancelled = false
+            queueMicrotask(() => {
+                if (cancelled) return
+                cleanup = scroll(animation, {
+                    ...options,
+                    axis,
+                    container: container?.current || undefined,
+                    target: target?.current || undefined,
+                })
+            })
+            return () => {
+                cancelled = true
+                cleanup?.()
+            }
+        },
         times: [0, 1],
         keyframes: [0, 1],
         ease: (v: number) => v,

--- a/packages/motion-dom/src/render/VisualElement.ts
+++ b/packages/motion-dom/src/render/VisualElement.ts
@@ -438,17 +438,6 @@ export abstract class VisualElement<
         }
     }
 
-    /**
-     * Register the instance with this VisualElement and the global
-     * visualElementStore. Idempotent — safe to call before mount() so that
-     * consumer ref callbacks can resolve the VisualElement via
-     * visualElementStore.get(instance).
-     */
-    register(instance: Instance) {
-        this.current = instance
-        visualElementStore.set(instance, this)
-    }
-
     mount(instance: Instance) {
         /**
          * If this element has been mounted before (e.g. after a Suspense
@@ -462,7 +451,9 @@ export abstract class VisualElement<
             }
         }
 
-        this.register(instance)
+        this.current = instance
+
+        visualElementStore.set(instance, this)
 
         if (this.projection && !this.projection.instance) {
             this.projection.mount(instance)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,65 +2242,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.5.10":
-  version: 15.5.10
-  resolution: "@next/env@npm:15.5.10"
-  checksum: cc481d2bd5a7cf97a0d3c093bb9a9b5359ad324c9eb26c89621c90f8d8d11a284fd05cdcc5358db973074fb65c0d9aa01ecbc464b181c9fe3b2bca0776a0fc54
+"@next/env@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/env@npm:15.5.15"
+  checksum: f07bf0f28bd71396e5f22328f4014fd64f4f7a175311d4d3e121797bd18f4635b8b906d4044709d20f5f55bdc2a6034dfa0acade4e152c1a733b61d4d08c500d
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-darwin-arm64@npm:15.5.7"
+"@next/swc-darwin-arm64@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-darwin-arm64@npm:15.5.15"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-darwin-x64@npm:15.5.7"
+"@next/swc-darwin-x64@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-darwin-x64@npm:15.5.15"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-linux-arm64-gnu@npm:15.5.7"
+"@next/swc-linux-arm64-gnu@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-arm64-gnu@npm:15.5.15"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-linux-arm64-musl@npm:15.5.7"
+"@next/swc-linux-arm64-musl@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-arm64-musl@npm:15.5.15"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-linux-x64-gnu@npm:15.5.7"
+"@next/swc-linux-x64-gnu@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-x64-gnu@npm:15.5.15"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-linux-x64-musl@npm:15.5.7"
+"@next/swc-linux-x64-musl@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-linux-x64-musl@npm:15.5.15"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-win32-arm64-msvc@npm:15.5.7"
+"@next/swc-win32-arm64-msvc@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-win32-arm64-msvc@npm:15.5.15"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/swc-win32-x64-msvc@npm:15.5.7"
+"@next/swc-win32-x64-msvc@npm:15.5.15":
+  version: 15.5.15
+  resolution: "@next/swc-win32-x64-msvc@npm:15.5.15"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6299,13 +6299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devalue@npm:^5.6.2":
-  version: 5.6.4
-  resolution: "devalue@npm:5.6.4"
-  checksum: 6c90626bf96864e1b20b29bf2a06b72d3779b75b562e84207295702874e31b3741836531a278d5915999a3aa0a3658b80ce0ee1967e373f5325b1ce2b66f3e46
-  languageName: node
-  linkType: hard
-
 "dezalgo@npm:^1.0.0":
   version: 1.0.4
   resolution: "dezalgo@npm:1.0.4"
@@ -7662,16 +7655,6 @@ __metadata:
   dependencies:
     map-cache: ^0.2.2
   checksum: 1cbbd0b0116b67d5790175de0038a11df23c1cd2e8dcdbade58ebba5594c2d641dade6b4f126d82a7b4a6ffc2ea12e3d387dbb64ea2ae97cf02847d436f60fdc
-  languageName: node
-  linkType: hard
-
-"framer-api@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "framer-api@npm:0.1.0"
-  dependencies:
-    devalue: ^5.6.2
-    std-env: ^3.10.0
-  checksum: 8224594208a42d5c52ea164a649b9ad8a8eb6608a4a1840f6a4b44badcda3facbffdb301ee66e2df4ebacd98bbe04c867a0c1b9bf5f6ae30e23ccae127d03003
   languageName: node
   linkType: hard
 
@@ -11233,7 +11216,6 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     eslint-plugin-redos-detector: ^2.4.0
     eslint-plugin-regexp: ^2.2.0
-    framer-api: ^0.1.0
     gsap: ^3.12.5
     jest: ^29.7.0
     jest-environment-jsdom: ^29.7.0
@@ -11241,7 +11223,6 @@ __metadata:
     jest-watch-typeahead: ^2.2.2
     lerna: ^4.0.0
     lint-staged: ^8.0.4
-    papaparse: ^5.5.3
     path-browserify: ^1.0.1
     prettier: ^2.5.1
     react: ^18.3.1
@@ -11392,25 +11373,25 @@ __metadata:
   resolution: "next-env@workspace:dev/next"
   dependencies:
     motion: ^12.38.0
-    next: 15.5.10
+    next: 15.5.15
     react: 19.0.0
     react-dom: 19.0.0
   languageName: unknown
   linkType: soft
 
-"next@npm:15.5.10":
-  version: 15.5.10
-  resolution: "next@npm:15.5.10"
+"next@npm:15.5.15":
+  version: 15.5.15
+  resolution: "next@npm:15.5.15"
   dependencies:
-    "@next/env": 15.5.10
-    "@next/swc-darwin-arm64": 15.5.7
-    "@next/swc-darwin-x64": 15.5.7
-    "@next/swc-linux-arm64-gnu": 15.5.7
-    "@next/swc-linux-arm64-musl": 15.5.7
-    "@next/swc-linux-x64-gnu": 15.5.7
-    "@next/swc-linux-x64-musl": 15.5.7
-    "@next/swc-win32-arm64-msvc": 15.5.7
-    "@next/swc-win32-x64-msvc": 15.5.7
+    "@next/env": 15.5.15
+    "@next/swc-darwin-arm64": 15.5.15
+    "@next/swc-darwin-x64": 15.5.15
+    "@next/swc-linux-arm64-gnu": 15.5.15
+    "@next/swc-linux-arm64-musl": 15.5.15
+    "@next/swc-linux-x64-gnu": 15.5.15
+    "@next/swc-linux-x64-musl": 15.5.15
+    "@next/swc-win32-arm64-msvc": 15.5.15
+    "@next/swc-win32-x64-msvc": 15.5.15
     "@swc/helpers": 0.5.15
     caniuse-lite: ^1.0.30001579
     postcss: 8.4.31
@@ -11453,7 +11434,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: c60fc5eb6d2fc7868a110a713fc772e69dfb0b13a64dc6ddb3b79a37bfe88c870433959337693b33bc88c1086a0c42e25b6eafbb6e198c935e7e7bff213c40e9
+  checksum: e65eaf1b2b755e132cfa1ca8df376471d8535dfa698f250bf0f433bfbf560b7e2b52cd7e26e56bd4998042d5bd7deee910c1df8cdb2dbb7a1a5bd4f3de56d8a5
   languageName: node
   linkType: hard
 
@@ -12241,13 +12222,6 @@ __metadata:
   bin:
     pacote: lib/bin.js
   checksum: 4fae0b1429be77e69972402dad24775999c92198dadc20f1f7a418f24e268e8bf85faaffc3f778d94c21348645f99bb65ef519fb82776902b556eef934afd932
-  languageName: node
-  linkType: hard
-
-"papaparse@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "papaparse@npm:5.5.3"
-  checksum: 369d68a16340e5fad95d411a0efca34bedbf93550744e6374fa9b60aaf6bc655e29a6d1a39a56afea0cf7dbc4454fd190f50a9ad76db80987b43d6c6c319f018
   languageName: node
   linkType: hard
 
@@ -14665,13 +14639,6 @@ __metadata:
     define-property: ^0.2.5
     object-copy: ^0.1.0
   checksum: 8657485b831f79e388a437260baf22784540417a9b29e11572c87735df24c22b84eda42107403a64b30861b2faf13df9f7fc5525d51f9d1d2303aba5cbf4e12c
-  languageName: node
-  linkType: hard
-
-"std-env@npm:^3.10.0":
-  version: 3.10.0
-  resolution: "std-env@npm:3.10.0"
-  checksum: 51d641b36b0fae494a546fb8446d39a837957fbf902c765c62bd12af8e50682d141c4087ca032f1192fa90330c4f6ff23fd6c9795324efacd1684e814471e0e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- `useScroll`'s acceleration factory reads `target.current` synchronously, but refs attach child-first during commit — so motion components *inside* the target run their `bindToMotionValue` first, when the target ref is still null.
- That null fallback caused `getTimeline()` to return a generic `ScrollTimeline` (default `cover` range) instead of the intended `ViewTimeline` with `contain` range.
- Visible symptom from #3658: nested-motion opacity already advanced when the section scrolled into view, and never reached its end value.

Closes #3658. Supersedes #3659 — that PR reverted only the string-offset path; the same bug also reproduced with the array-form `[[0,0],[1,1]]` offset that was acceleration-eligible since the original ViewTimeline support landed.

## Fix

Defer the `scroll()` call inside `makeAccelerateConfig`'s factory by one microtask. By the time the microtask runs, all ref callbacks queued in the same commit have fired, so `target.current` is populated before `getTimeline()` inspects it.

The deferral is one microtask, well before the next paint, so no visual flash.

## Test plan

- [x] New Cypress regression test in `scroll-view-timeline-transformed-parent.ts` that mirrors the reporter's repro structure (literal port).
  - Asserts `getAnimations()[0].timeline` is a `ViewTimeline` and `rangeStart`/`rangeEnd` are `contain ...`.
  - Compares compositor-driven `getComputedStyle(opacity)` against JS scrollInfo progress at six scroll positions; max drift must be < 0.01.
  - Verified to **fail** without the fix (`expected 'ScrollTimeline' to equal 'ViewTimeline'`).
- [x] Existing Cypress scroll specs still pass on React 18 + Chrome:
  - `scroll-view-timeline.ts` (3/3)
  - `scroll-target-transform.ts` (2/2)
  - `scroll-accelerate.ts` (3/3)
- [x] Same set passes on React 19 + Chrome.
- [x] `use-scroll.test.tsx` jest unit tests pass (6/6).

## Why real Chrome

Electron's WAAPI/ViewTimeline implementation differs from production Chrome — the regression surface is compositor behavior, so the cypress run must use `--browser chrome`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)