### PR TITLE
Investigation: SVG path morphing (#3681)

### DIFF
--- a/packages/framer-motion/src/motion/__tests__/svg-path.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/svg-path.test.tsx
@@ -22,4 +22,26 @@ describe("SVG path", () => {
         expect(element).toHaveAttribute("stroke-dasharray", "1 1")
         expect(element).toHaveAttribute("pathLength", "1")
     })
+
+    test("animates d between paths with matching command structure", async () => {
+        const element = await new Promise<SVGPathElement | null>((resolve) => {
+            const ref = createRef<SVGPathElement>()
+            const Component = ({ d }: { d: string }) => (
+                <svg>
+                    <motion.path
+                        ref={ref}
+                        initial={{ d: "M 0 0 L 100 0 L 100 100 L 0 100 Z" }}
+                        animate={{ d }}
+                        transition={{ duration: 0.01 }}
+                        onAnimationComplete={() => resolve(ref.current)}
+                    />
+                </svg>
+            )
+            const target = "M 50 0 L 100 50 L 50 100 L 0 50 Z"
+            const { rerender } = render(<Component d={target} />)
+            rerender(<Component d={target} />)
+        })
+
+        expect(element).toHaveAttribute("d", "M 50 0 L 100 50 L 50 100 L 0 50 Z")
+    })
 })


### PR DESCRIPTION
## Summary

Investigation notes for #3681. Adds a regression-guard test for the existing `d`-attribute morphing that already works between paths with matching command structure. Does **not** add GSAP MorphSVG-style cross-structure path morphing.

Fixes #3681 (closing as not-implementing — see context below).

## Context

This issue is essentially a duplicate of #1392 ("GSAP MorphSVGPlugin equivalent?"), which I closed in 2022. That ask was declined for the same reasons that still apply today, and at the time I pointed users to a flubber.js-based recipe: https://codesandbox.io/s/framer-motion-morphsvg-example-dp7to

## What Motion already supports for SVG

- **Line drawing** — `pathLength`, `pathOffset`, `pathSpacing` motion values (built-in, no extra deps).
- **Path morphing between same-structure paths** — `animate={{ d: \"...\" }}` works through the complex value mixer when source and target paths share the same sequence of M/L/C/Z commands. The mixer extracts numeric tokens and interpolates them; the surrounding path structure is shared template text. Now covered by the test in this PR.
- **Path morphing between arbitrary paths** — out of scope. Use [flubber](https://github.com/veltman/flubber) (or similar) and feed the interpolated string into a `MotionValue<string>`.

## What GSAP MorphSVG does that Motion doesn't

GSAP's MorphSVGPlugin (their premium-tier plugin) handles morphing between paths with completely different structure:

1. Parse `d` into command/point arrays.
2. Normalize all commands to cubic béziers.
3. Match points between source and target (closest-point matching, optional shape-matching).
4. Insert/remove points so counts align.
5. Interpolate each point.

That's a substantial library on its own (flubber.js exists specifically for this and is ~500 LOC of nontrivial geometry). Bundling it into Motion would add weight that most users don't need, and the plugin-style integration is what we already point users at.

## Why this PR is a draft / not implementing

- Same maintainer decision as #1392 — recommend external lib (flubber) for the cross-structure case.
- A first-class implementation needs API design (component-level vs. utility, where to expose path normalization, how to handle multi-subpath `d` values, etc.) — not appropriate for an issue-fixer pass.
- The user's stated wins ("simple line drawing or morphing") are largely already supported; the discoverability problem belongs in the docs (motion.dev), not the library.

## What this PR adds

A single Jest test in `svg-path.test.tsx` that asserts `motion.path` correctly resolves an animated `d` attribute target between two structurally-similar paths. Acts as a regression guard for the path most users actually hit, and as inline documentation that this case works.

## Recommendation

Close #3681 as a duplicate of #1392, ideally with a comment pointing at the flubber recipe and `pathLength`/`pathOffset`/`pathSpacing` for the line-drawing case.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` — new test passes; only failing test is a pre-existing flake in `AnimatePresence` ("Elements exit in sequence during fast renders") unrelated to this change (passes in isolation, fails only in full-suite runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)