### PR TITLE
Export motion.create from motion/react-client

### DIFF
--- a/packages/framer-motion/src/client.ts
+++ b/packages/framer-motion/src/client.ts
@@ -23,6 +23,7 @@ export {
     code,
     col,
     colgroup,
+    create,
     data,
     datalist,
     dd,

--- a/packages/framer-motion/src/motion/__tests__/client-export.ssr.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/client-export.ssr.test.tsx
@@ -1,0 +1,19 @@
+import { renderToString } from "react-dom/server"
+import * as motion from "../../client"
+
+describe("framer-motion/client export", () => {
+    test("exports motion.create for use in React Server Components", () => {
+        expect(typeof (motion as any).create).toBe("function")
+    })
+
+    test("motion.create returns a working component when called from the client export", () => {
+        const CustomDiv = (motion as any).create("div")
+        const output = renderToString(
+            <CustomDiv initial={{ x: 100 }} style={{ opacity: 1 }} />
+        )
+
+        expect(output).toBe(
+            '<div style="opacity:1;transform:translateX(100px)"></div>'
+        )
+    })
+})


### PR DESCRIPTION
## Summary

`motion/react-client` is the recommended way to use Motion in React Server Components — `import * as motion from "motion/react-client"` lets users render `<motion.div />` etc. without `'use client'`. However, `motion.create` (used to wrap custom components or create motion components for arbitrary tags) was missing from this export, so users still had to fall back to `'use client'` whenever they needed a custom motion component.

This is a known papercut from issue #2902 — multiple users reported the same workaround in the comments and noted that `motion.create()` was the one thing they couldn't do from RSC.

## Cause

`packages/framer-motion/src/client.ts` was rewritten in commit `4d607bf1d` (PR #3353) to enumerate named exports rather than `export *`, fixing a Next.js error: *"It's currently unsupported to use 'export *' in a client boundary"*. The rewrite enumerated every element (`a`, `div`, `circle`, ...) but accidentally dropped `create` from the namespace, even though it's exported alongside the elements from `src/render/components/motion/namespace.ts`.

## Fix

Add `create` to the named export list in `client.ts`. The function comes from the same `'use client'` module as the elements and follows the exact same export pattern, so it's safe with respect to the original Next.js client-boundary fix.

## Test plan

- [x] New `client-export.ssr.test.tsx` SSR test asserts `motion.create` is a function when imported from `framer-motion/client` and that the resulting component renders correctly via `renderToString`. Test fails on `main` (`motion.create is not a function`) and passes with the fix.
- [x] `yarn build` passes for all packages, including `dev/next` (Next.js App Router build).
- [x] `yarn test` passes (778 client tests + 51 SSR tests).

Fixes #2902