### PR TITLE
Bundle framer-motion types into self-contained .d.ts files

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -6,7 +6,7 @@
     "module": "dist/es/index.mjs",
     "exports": {
         ".": {
-            "types": "./dist/types/index.d.ts",
+            "types": "./dist/index.d.ts",
             "require": "./dist/cjs/index.js",
             "import": "./dist/es/index.mjs",
             "default": "./dist/cjs/index.js"
@@ -30,7 +30,7 @@
             "default": "./dist/cjs/dom.js"
         },
         "./client": {
-            "types": "./dist/types/client.d.ts",
+            "types": "./dist/client.d.ts",
             "require": "./dist/cjs/client.js",
             "import": "./dist/es/client.mjs",
             "default": "./dist/cjs/client.js"
@@ -54,7 +54,7 @@
         },
         "./package.json": "./package.json"
     },
-    "types": "dist/types/index.d.ts",
+    "types": "dist/index.d.ts",
     "author": "Matt Perry",
     "license": "MIT",
     "repository": "https://github.com/motiondivision/motion/",

--- a/packages/framer-motion/rollup.config.mjs
+++ b/packages/framer-motion/rollup.config.mjs
@@ -163,18 +163,7 @@ export const es = Object.assign({}, config, {
 
 const typePlugins = [dts({compilerOptions: {...tsconfig, baseUrl:"types"}})]
 
-const types = {
-    input: ["types/index.d.ts", "types/client.d.ts"],
-    output: {
-        format: "es",
-        entryFileNames: "[name].d.ts",
-        dir: "dist",
-    },
-    plugins: typePlugins,
-}
-
-
-function createTypes(input, file) {   
+function createTypes(input, file) {
     return {
         input,
         output: {
@@ -185,7 +174,8 @@ function createTypes(input, file) {
     }
 }
 
-
+const indexTypes = createTypes("types/index.d.ts", "dist/index.d.ts")
+const clientTypes = createTypes("types/client.d.ts", "dist/client.d.ts")
 const miniTypes = createTypes("types/mini.d.ts", "dist/mini.d.ts")
 const debugTypes = createTypes("types/debug.d.ts", "dist/debug.d.ts")
 const animateTypes = createTypes("types/dom.d.ts", "dist/dom.d.ts")
@@ -207,7 +197,8 @@ export default [
     cjsDomMini,
     cjsM,
     es,
-    types,
+    indexTypes,
+    clientTypes,
     debugTypes,
     mTypes,
     miniTypes,

--- a/packages/framer-motion/scripts/check-bundle.js
+++ b/packages/framer-motion/scripts/check-bundle.js
@@ -1,11 +1,35 @@
 const path = require("path")
-const { readFileSync } = require("fs")
+const { existsSync, readFileSync } = require("fs")
+const pkg = require("../package.json")
 
-const file = readFileSync(
-    path.join(__dirname, "../", "dist", "dom.d.ts"),
-    "utf8"
-)
+const dist = path.join(__dirname, "..", "dist")
+
+const file = readFileSync(path.join(dist, "dom.d.ts"), "utf8")
 
 if (file.includes(`<reference types="react" />`)) {
     throw new Error("DOM bundle includes reference to React")
+}
+
+/**
+ * Verify every "types" entry in package.json exports points to a file that
+ * exists, and that the bundled .d.ts file is self-contained (no relative
+ * imports of internal chunks). Issue #2900.
+ */
+for (const [name, entry] of Object.entries(pkg.exports)) {
+    if (!entry || typeof entry !== "object" || !entry.types) continue
+
+    const typesPath = path.join(__dirname, "..", entry.types)
+    if (!existsSync(typesPath)) {
+        throw new Error(
+            `Types file for "${name}" (${entry.types}) does not exist`
+        )
+    }
+
+    const contents = readFileSync(typesPath, "utf8")
+    const relativeImport = contents.match(/from ['"](\.[^'"]+)['"]/)
+    if (relativeImport) {
+        throw new Error(
+            `Types file for "${name}" (${entry.types}) contains a relative import (${relativeImport[1]}) — types must be bundled into a single self-contained file`
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Bundles `framer-motion`'s `"."` and `"./client"` type entry points into self-contained `.d.ts` files, matching how the other entry points (`debug`, `mini`, `dom`, `m`, etc.) are already shipped.

## Problem

The previous rollup config ran both `types/index.d.ts` and `types/client.d.ts` through `rollup-plugin-dts` in a single config, which caused the plugin to extract shared types into a chunk file (e.g. `dist/types.d-DOCC-kZB.d.ts`) and emit the bundled types into `dist/types/` instead of `dist/`. `package.json` then pointed at `./dist/types/index.d.ts` and `./dist/types/client.d.ts`.

This breaks TypeScript setups that map each package's types via `tsconfig.json` `paths`, since each declared types entry needs to be a single self-contained file. It also produced an internal chunk file that consumers had to ship alongside the entry types.

## Fix

- Split the types rollup config so `index.d.ts` and `client.d.ts` are each bundled independently using the same `createTypes` helper as the other entry points.
- Output goes directly to `dist/index.d.ts` and `dist/client.d.ts`.
- `package.json` updated to point `"."` and `"./client"` (and the top-level `"types"` field) at the new paths.
- Extended `scripts/check-bundle.js` to assert that every `types` entry in `package.json` exports points to a file that exists and contains no relative imports of internal chunks. This is the regression gate.

Fixes #2900

## Test plan

- [x] `yarn build` succeeds; `dist/index.d.ts` and `dist/client.d.ts` exist as single bundled files
- [x] No internal chunk files (e.g. `dist/types.d-DOCC-kZB.d.ts`) emitted
- [x] `node scripts/check-bundle.js` passes for all entry points
- [x] `yarn test` — 778 tests pass
- [x] Verified the issue's `tsconfig.json` `paths` scenario type-checks against the built output