### PR TITLE
Fix scroll callback ignoring offset when info parameter omitted

### DIFF
--- a/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { frame } from "motion-dom"
+import { frame, supportsFlags } from "motion-dom"
 import { scroll } from "../"
 import { ScrollOffset } from "../offsets/presets"
 import { scrollInfo } from "../track"
@@ -833,5 +833,57 @@ describe("scroll", () => {
 
             resolve()
         })
+    })
+
+    test("Respects offset when callback has no info parameter (#3668).", async () => {
+        // Force the native ScrollTimeline code path. JSDOM doesn't define
+        // window.ScrollTimeline, so without the support flag the code falls
+        // through to the JS scrollInfo path and the bug doesn't reproduce.
+        class FakeScrollTimeline {
+            currentTime: { value: number } | null = { value: 30 }
+            constructor(_options: any) {}
+        }
+        const originalScrollTimeline = (window as any).ScrollTimeline
+        ;(window as any).ScrollTimeline = FakeScrollTimeline
+        supportsFlags.scrollTimeline = true
+
+        try {
+            await fireScroll(0)
+            setWindowHeight(1000)
+            setDocumentHeight(3000)
+
+            let receivedProgress: number | undefined
+
+            // 1-arg callback (no info parameter) with offset.
+            // Without the fix, the native ScrollTimeline path is taken and
+            // offsets are silently ignored — the callback would receive the
+            // FakeScrollTimeline.currentTime.value / 100 = 0.3.
+            const stopScroll = scroll(
+                (progress: number) => {
+                    receivedProgress = progress
+                },
+                { offset: [0.5, 1] }
+            )
+
+            await fireScroll(600)
+            // Raw scroll progress = 600 / 2000 = 0.3.
+            // With offset [0.5, 1] applied, progress should be clamped to 0
+            // because we haven't yet reached the start of the offset range.
+            expect(receivedProgress).toBeCloseTo(0)
+
+            await fireScroll(1500)
+            // Raw progress = 1500 / 2000 = 0.75.
+            // With offset [0.5, 1]: (0.75 - 0.5) / (1 - 0.5) = 0.5
+            expect(receivedProgress).toBeCloseTo(0.5)
+
+            stopScroll()
+        } finally {
+            supportsFlags.scrollTimeline = undefined
+            if (originalScrollTimeline === undefined) {
+                delete (window as any).ScrollTimeline
+            } else {
+                ;(window as any).ScrollTimeline = originalScrollTimeline
+            }
+        }
     })
 })

--- a/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
@@ -836,12 +836,10 @@ describe("scroll", () => {
     })
 
     test("Respects offset when callback has no info parameter (#3668).", async () => {
-        // Force the native ScrollTimeline code path. JSDOM doesn't define
-        // window.ScrollTimeline, so without the support flag the code falls
-        // through to the JS scrollInfo path and the bug doesn't reproduce.
+        // JSDOM lacks window.ScrollTimeline; fake it so the native code path
+        // is taken — that's the path that previously dropped offsets.
         class FakeScrollTimeline {
             currentTime: { value: number } | null = { value: 30 }
-            constructor(_options: any) {}
         }
         const originalScrollTimeline = (window as any).ScrollTimeline
         ;(window as any).ScrollTimeline = FakeScrollTimeline
@@ -854,10 +852,6 @@ describe("scroll", () => {
 
             let receivedProgress: number | undefined
 
-            // 1-arg callback (no info parameter) with offset.
-            // Without the fix, the native ScrollTimeline path is taken and
-            // offsets are silently ignored — the callback would receive the
-            // FakeScrollTimeline.currentTime.value / 100 = 0.3.
             const stopScroll = scroll(
                 (progress: number) => {
                     receivedProgress = progress
@@ -865,15 +859,14 @@ describe("scroll", () => {
                 { offset: [0.5, 1] }
             )
 
+            // scrollLength = 2000. raw progress 600/2000 = 0.3, before offset
+            // start of 0.5 → clamped to 0. Without the fix, callback would
+            // receive FakeScrollTimeline.currentTime.value / 100 = 0.3.
             await fireScroll(600)
-            // Raw scroll progress = 600 / 2000 = 0.3.
-            // With offset [0.5, 1] applied, progress should be clamped to 0
-            // because we haven't yet reached the start of the offset range.
             expect(receivedProgress).toBeCloseTo(0)
 
+            // raw 1500/2000 = 0.75 → (0.75 - 0.5) / (1 - 0.5) = 0.5
             await fireScroll(1500)
-            // Raw progress = 1500 / 2000 = 0.75.
-            // With offset [0.5, 1]: (0.75 - 0.5) / (1 - 0.5) = 0.5
             expect(receivedProgress).toBeCloseTo(0.5)
 
             stopScroll()

--- a/packages/framer-motion/src/render/dom/scroll/attach-function.ts
+++ b/packages/framer-motion/src/render/dom/scroll/attach-function.ts
@@ -2,6 +2,7 @@ import { observeTimeline } from "motion-dom"
 import { scrollInfo } from "./track"
 import { OnScroll, OnScrollWithInfo, ScrollOptionsWithDefaults } from "./types"
 import { getTimeline } from "./utils/get-timeline"
+import { isElementTracking } from "./utils/is-element-tracking"
 
 /**
  * If the onScroll function has two arguments, it's expecting
@@ -15,11 +16,7 @@ export function attachToFunction(
     onScroll: OnScroll,
     options: ScrollOptionsWithDefaults
 ) {
-    /**
-     * Native ScrollTimeline ignores `offset`/`target`, so the JS scrollInfo
-     * path is required whenever either is set — even for 1-arg callbacks.
-     */
-    if (isOnScrollWithInfo(onScroll) || options.offset || options.target) {
+    if (isOnScrollWithInfo(onScroll) || isElementTracking(options)) {
         return scrollInfo((info) => {
             onScroll(info[options.axis!].progress, info)
         }, options)

--- a/packages/framer-motion/src/render/dom/scroll/attach-function.ts
+++ b/packages/framer-motion/src/render/dom/scroll/attach-function.ts
@@ -15,7 +15,11 @@ export function attachToFunction(
     onScroll: OnScroll,
     options: ScrollOptionsWithDefaults
 ) {
-    if (isOnScrollWithInfo(onScroll)) {
+    /**
+     * Native ScrollTimeline ignores `offset`/`target`, so the JS scrollInfo
+     * path is required whenever either is set — even for 1-arg callbacks.
+     */
+    if (isOnScrollWithInfo(onScroll) || options.offset || options.target) {
         return scrollInfo((info) => {
             onScroll(info[options.axis!].progress, info)
         }, options)


### PR DESCRIPTION
## Summary

When `scroll(callback, { offset })` is called with a 1-arg callback (no `info` parameter), the configured `offset` was silently ignored — the callback received raw scroll progress regardless of the offset range.

## Cause

`attachToFunction` switched paths based solely on the callback's arity:

- 2-arg callback → `scrollInfo` path (JS, honours `offset` and `target`)
- 1-arg callback → `observeTimeline(getTimeline(...))` path

The 1-arg path resolves to a native `ScrollTimeline` (when supported), and native `ScrollTimeline` only takes `source` and `axis` — it has no concept of offsets. The JS fallback inside `getTimeline` only kicks in when `ScrollTimeline` is unavailable, so on modern browsers the offset was dropped.

## Fix

Route through `scrollInfo` whenever `offset` or `target` is provided, regardless of callback arity. The 1-arg callback still receives just the progress, but it's now the offset-aware progress from `scrollInfo`.

## Test plan

- [x] Added regression test in `packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts` that mocks `window.ScrollTimeline` and `supportsFlags.scrollTimeline` to force the native path, then verifies the offset is applied.
- [x] Test fails before the fix (receives raw progress 0.3 instead of offset-adjusted 0).
- [x] `yarn build` and `yarn test` pass (779 tests, 10 skipped).

Fixes #3668

🤖 Generated with [Claude Code](https://claude.com/claude-code)