### PR TITLE
test(drag): Cover imperative resize regression for #2903

### DIFF
--- a/dev/react/src/tests/drag-ref-constraints-resize-handle.tsx
+++ b/dev/react/src/tests/drag-ref-constraints-resize-handle.tsx
@@ -1,0 +1,63 @@
+import { motion } from "framer-motion"
+import { useRef } from "react"
+
+/**
+ * Test page for issue #2903: Drag constraints should update when the
+ * draggable element is resized. Mirrors the CodeSandbox reproduction
+ * which uses an externally-resizable modal (e.g. CSS `resize: both`
+ * or imperative DOM resizing) where React state never changes.
+ *
+ * Container: 500x500
+ * Draggable: starts at 100x100. Clicking the resize button mutates the
+ * element's inline style directly — bypassing React state — so the only
+ * signal that the size changed is ResizeObserver (matching the native
+ * CSS resize-handle behaviour described in the issue).
+ */
+export const App = () => {
+    const constraintsRef = useRef<HTMLDivElement>(null)
+    const boxRef = useRef<HTMLDivElement>(null)
+
+    const onResize = () => {
+        if (boxRef.current) {
+            boxRef.current.style.width = "300px"
+            boxRef.current.style.height = "300px"
+        }
+    }
+
+    return (
+        <div style={{ padding: 0, margin: 0 }}>
+            <button
+                id="resize-trigger"
+                onClick={onResize}
+                style={{ position: "fixed", top: 10, right: 10, zIndex: 10 }}
+            >
+                Resize to 300x300
+            </button>
+            <motion.div
+                id="constraints"
+                ref={constraintsRef}
+                style={{
+                    width: 500,
+                    height: 500,
+                    background: "rgba(0, 0, 255, 0.1)",
+                    position: "relative",
+                }}
+            >
+                <motion.div
+                    id="box"
+                    data-testid="draggable"
+                    ref={boxRef}
+                    drag
+                    dragConstraints={constraintsRef}
+                    dragElastic={0}
+                    dragMomentum={false}
+                    style={{
+                        width: 100,
+                        height: 100,
+                        background: "red",
+                    }}
+                />
+            </motion.div>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/drag-ref-constraints-resize-handle.ts
+++ b/packages/framer-motion/cypress/integration/drag-ref-constraints-resize-handle.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for issue #2903: Drag constraints should update when the
+ * draggable element is resized via a path that bypasses React state
+ * (e.g. CSS `resize: both` or imperative DOM resizing — the scenario
+ * described in the linked CodeSandbox).
+ *
+ * - Container (#constraints): 500x500
+ * - Draggable (#box): starts 100x100, grows to 300x300 when
+ *   #resize-trigger is clicked. The handler mutates the element's
+ *   inline style directly so the only signal of the size change is
+ *   ResizeObserver — projection's normal lifecycle does not fire.
+ *
+ * Before resize: max travel = 400px (500 - 100)
+ * After resize:  max travel = 200px (500 - 300)
+ */
+describe("Drag Constraints Update on Imperative Resize", () => {
+    it("Updates drag constraints when element grows via direct DOM mutation", () => {
+        cy.visit("?test=drag-ref-constraints-resize-handle").wait(200)
+
+        cy.get("#resize-trigger").click().wait(200)
+
+        cy.get("#box").should(($box: any) => {
+            const box = $box[0] as HTMLDivElement
+            const { width, height } = box.getBoundingClientRect()
+            expect(width).to.equal(300)
+            expect(height).to.equal(300)
+        })
+
+        cy.get("#box")
+            .trigger("pointerdown", 5, 5)
+            .trigger("pointermove", 10, 10)
+            .wait(50)
+            .trigger("pointermove", 600, 600, { force: true })
+            .wait(50)
+            .trigger("pointerup", { force: true })
+            .wait(50)
+            .should(($box: any) => {
+                const box = $box[0] as HTMLDivElement
+                const { right, bottom } = box.getBoundingClientRect()
+                // 300x300 box must stay inside the 500x500 container.
+                // Without the fix, right/bottom would be ~700.
+                expect(right).to.be.at.most(502)
+                expect(bottom).to.be.at.most(502)
+            })
+    })
+})


### PR DESCRIPTION
## Summary

Issue #2903 reports the same bug as #2458: drag constraints stop matching the draggable element when it is resized. #2458 was fixed by PR #3522, which added a ResizeObserver in `VisualElementDragControls.addListeners` so constraints update for resizes that happen outside React state (e.g. CSS `resize: both`, imperative DOM mutations, or motion-value-driven width/height).

The existing regression test (`drag-ref-constraints-element-resize`) covers motion-value-driven resizes. This PR adds a complementary test that covers the imperative-DOM-resize path described in the #2903 reproduction (a modal whose dimensions change via direct `style.width`/`style.height` mutation, bypassing React entirely). Without the ResizeObserver in `VisualElementDragControls`, this new test fails — the draggable overflows the 500x500 constraint container by ~200px after resize.

The fix shipped with #2458 already addresses the reported behaviour. This PR strengthens the regression net so the imperative-resize scenario from #2903 cannot silently regress.

Fixes #2903

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (778 tests, 10 skipped)
- [x] `cypress run --spec cypress/integration/drag-ref-constraints-resize-handle.ts` passes on React 18
- [x] `cypress run --config-file=cypress.react-19.json --spec cypress/integration/drag-ref-constraints-resize-handle.ts` passes on React 19
- [x] All 91 drag-related Cypress tests still pass
- [x] Verified the new test fails on a build with the ResizeObserver fix removed