### PR TITLE
Fix scroll() ignoring offset with single-arg callback (#3668)

### DIFF
--- a/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { frame } from "motion-dom"
+import { frame, supportsFlags } from "motion-dom"
 import { scroll } from "../"
 import { ScrollOffset } from "../offsets/presets"
 import { scrollInfo } from "../track"
@@ -833,5 +833,45 @@ describe("scroll", () => {
 
             resolve()
         })
+    })
+
+    test("Honors offset option with single-argument callback when ScrollTimeline is supported (#3668).", async () => {
+        class MockScrollTimeline {
+            currentTime: { value: number } | null = { value: 0 }
+            constructor(_options: any) {}
+        }
+
+        const originalScrollTimeline = (window as any).ScrollTimeline
+        ;(window as any).ScrollTimeline = MockScrollTimeline
+        supportsFlags.scrollTimeline = true
+
+        try {
+            let oneArgProgress = -1
+
+            setWindowHeight(1000)
+            setDocumentHeight(3000)
+
+            const stopOneArg = scroll(
+                (progress: number) => {
+                    oneArgProgress = progress
+                },
+                { offset: ["start start", "end end"] }
+            )
+
+            await nextFrame()
+            await fireScroll(500)
+            // Fallback path needs an additional frame for the timeline value
+            // to propagate from scrollInfo notify → observeTimeline preUpdate.
+            await nextFrame()
+
+            // With offset honored, progress should reflect actual scroll
+            // position (500 / (3000 - 1000) = 0.25), not stay at 0.
+            expect(oneArgProgress).toBeCloseTo(0.25, 5)
+
+            stopOneArg()
+        } finally {
+            ;(window as any).ScrollTimeline = originalScrollTimeline
+            delete supportsFlags.scrollTimeline
+        }
     })
 })

--- a/packages/framer-motion/src/render/dom/scroll/attach-animation.ts
+++ b/packages/framer-motion/src/render/dom/scroll/attach-animation.ts
@@ -22,7 +22,7 @@ export function attachToAnimation(
      */
     const useNative = options.target
         ? canUseNativeTimeline(options.target) && !!range
-        : canUseNativeTimeline()
+        : canUseNativeTimeline() && !options.offset
 
     return animation.attachTimeline({
         timeline: useNative ? timeline : undefined,

--- a/packages/framer-motion/src/render/dom/scroll/utils/get-timeline.ts
+++ b/packages/framer-motion/src/render/dom/scroll/utils/get-timeline.ts
@@ -73,7 +73,7 @@ export function getTimeline({
                     ...options,
                 })
             }
-        } else if (canUseNativeTimeline()) {
+        } else if (!options.offset && canUseNativeTimeline()) {
             targetCache[axisKey] = new ScrollTimeline({
                 source: container,
                 axis,


### PR DESCRIPTION
## Summary
- `scroll(callback, { offset })` was silently dropping the `offset` option whenever the callback only accepted the `progress` argument (e.g. `scroll((progress) => …, { offset })`).
- In browsers that support native `ScrollTimeline` (Chrome), `getTimeline()` took the bare `new ScrollTimeline({ source, axis })` branch — which has no concept of custom offset ranges — instead of falling back to the JS scroll-info path that interprets `offset`.
- Skip the bare native `ScrollTimeline` branch when an `offset` is provided so the JS fallback runs and the offsets are honored. Apply the same guard to `attachToAnimation`'s `useNative` flag so animations stay in sync with `getTimeline`'s decision.

## Cause
`getTimeline()` in `packages/framer-motion/src/render/dom/scroll/utils/get-timeline.ts` selected `new ScrollTimeline({ source, axis })` whenever the browser supported it, regardless of whether the user supplied an `offset`. `ScrollTimeline` only honors source + axis (it doesn't accept range/offset like `ViewTimeline`), so the offset was silently ignored. The two-argument callback path (`scroll((progress, info) => …)`) didn't hit this branch — it went through `scrollInfo()` directly — which is why the bug only manifested with the single-argument callback.

## Fix
- `get-timeline.ts`: only take the native `ScrollTimeline` branch when `options.offset` is unset; otherwise fall through to `scrollTimelineFallback`.
- `attach-animation.ts`: align `useNative` so animations also use the JS fallback when `offset` is set without a target capable of using `ViewTimeline`.

## Test plan
- [x] Added unit test in `packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts` that mocks `window.ScrollTimeline` + sets `supportsFlags.scrollTimeline = true` to reproduce the Chrome path inside JSDOM, with a single-arg callback. Test fails on `main`, passes with the fix.
- [x] `yarn build` ✅
- [x] `yarn test` (777 passed) ✅

Fixes #3668