### PR TITLE
Document motion/react-client for Next.js App Router (#2902)

### DIFF
--- a/packages/framer-motion/README.md
+++ b/packages/framer-motion/README.md
@@ -49,6 +49,22 @@ Get started with [Motion for React](https://motion.dev/docs/react).
 
 **Note:** Framer Motion is now Motion. Import from `motion/react` instead of `framer-motion`.
 
+#### Next.js / React Server Components
+
+To use `motion` directly inside a [React Server Component](https://react.dev/reference/rsc/server-components) (e.g. the Next.js App Router) without adding `"use client"` to your file, import from `motion/react-client`:
+
+```jsx
+import * as motion from "motion/react-client"
+
+export default function Page() {
+    return <motion.div animate={{ x: 100 }} />
+}
+```
+
+Other client-only APIs (`AnimatePresence`, `MotionConfig`, `useMotionValue` and friends) can still be imported from `motion/react` — they include the `"use client"` directive internally and work from Server Components without further setup.
+
+Custom motion components created with `motion.create()` must live in a file marked with `"use client"`, because the call runs at render time. Define them in a client module and render them from your Server Component.
+
 ### JS
 
 ```javascript

--- a/packages/motion/README.md
+++ b/packages/motion/README.md
@@ -53,6 +53,22 @@ Get started with [Motion for React](https://motion.dev/docs/react).
 
 **Note:** Framer Motion is now Motion. Import from `motion/react` instead of `framer-motion`.
 
+#### Next.js / React Server Components
+
+To use `motion` directly inside a [React Server Component](https://react.dev/reference/rsc/server-components) (e.g. the Next.js App Router) without adding `"use client"` to your file, import from `motion/react-client`:
+
+```jsx
+import * as motion from "motion/react-client"
+
+export default function Page() {
+    return <motion.div animate={{ x: 100 }} />
+}
+```
+
+Other client-only APIs (`AnimatePresence`, `MotionConfig`, `useMotionValue` and friends) can still be imported from `motion/react` — they include the `"use client"` directive internally and work from Server Components without further setup.
+
+Custom motion components created with `motion.create()` must live in a file marked with `"use client"`, because the call runs at render time. Define them in a client module and render them from your Server Component.
+
 ### JS
 
 ```javascript


### PR DESCRIPTION
## Summary

Adds a brief "Next.js / React Server Components" section to the `motion` and `framer-motion` package READMEs, showing the `motion/react-client` import pattern for use directly inside Server Components without manually adding `"use client"`.

## Why

[Issue #2902](https://github.com/motiondivision/motion/issues/2902) asks how to use Motion in a Next.js 14 SSR / App Router environment without adding `"use client"` at the top of every file. The supported entry point already exists — `motion/react-client` — but as the maintainer and commenters noted, it's "kind of hidden" in the docs. This change makes the pattern visible on the npm package landing page.

The snippet covers:

- `import * as motion from "motion/react-client"` — works directly inside a Server Component.
- Other client-only APIs (`AnimatePresence`, `MotionConfig`, `useMotionValue`, …) can still be imported from `motion/react`; their source modules already carry `"use client"` so they cross the boundary cleanly.
- `motion.create()` runs at render time, so custom motion components must live in a `"use client"` module.

## Notes

- Docs-only change, no runtime/code changes.
- One pre-existing flaky test (`AnimatePresence > popLayout mode with anchorY='bottom' preserves bottom positioning`) timed out under full-suite load but passes when run in isolation; unrelated to this change.

Fixes #2902

## Test plan

- [x] `yarn build`
- [x] `yarn test` (one pre-existing flake noted above; verified passing in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)