### PR TITLE
Skip non-static position warning for document scroll containers

### DIFF
--- a/packages/framer-motion/src/render/dom/scroll/__tests__/on-scroll-handler.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/__tests__/on-scroll-handler.test.ts
@@ -1,0 +1,62 @@
+import { createScrollInfo } from "../info"
+import { createOnScrollHandler } from "../on-scroll-handler"
+
+describe("on-scroll-handler static-position warning", () => {
+    let consoleWarnSpy: jest.SpyInstance
+    let getComputedStyleSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        consoleWarnSpy = jest
+            .spyOn(console, "warn")
+            .mockImplementation(() => {})
+        getComputedStyleSpy = jest
+            .spyOn(window, "getComputedStyle")
+            .mockReturnValue({
+                position: "static",
+            } as CSSStyleDeclaration)
+    })
+
+    afterEach(() => {
+        consoleWarnSpy.mockRestore()
+        getComputedStyleSpy.mockRestore()
+    })
+
+    const didWarn = () =>
+        consoleWarnSpy.mock.calls.some((args) =>
+            args.some(
+                (arg: unknown) =>
+                    typeof arg === "string" &&
+                    arg.includes("non-static position")
+            )
+        )
+
+    const measureWith = (container: Element, target: Element) => {
+        const handler = createOnScrollHandler(
+            container,
+            () => {},
+            createScrollInfo(),
+            { target }
+        )
+        handler.measure(0)
+    }
+
+    test("does not warn when container is document.documentElement", () => {
+        const target = document.createElement("div")
+        document.body.appendChild(target)
+
+        measureWith(document.documentElement, target)
+
+        expect(didWarn()).toBe(false)
+    })
+
+    test("warns when a custom container has static position", () => {
+        const container = document.createElement("div")
+        const target = document.createElement("div")
+        container.appendChild(target)
+        document.body.appendChild(container)
+
+        measureWith(container, target)
+
+        expect(didWarn()).toBe(true)
+    })
+})

--- a/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
+++ b/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
@@ -36,10 +36,18 @@ function measure(
 
     /**
      * In development mode ensure scroll containers aren't position: static as this makes
-     * it difficult to measure their relative positions.
+     * it difficult to measure their relative positions. The document scrolling element
+     * is exempt: offsetParent measurements naturally resolve relative to the document.
      */
     if (process.env.NODE_ENV !== "production") {
-        if (container && target && target !== container) {
+        if (
+            container &&
+            target &&
+            target !== container &&
+            container !== document.documentElement &&
+            container !== document.scrollingElement &&
+            container !== document.body
+        ) {
             warnOnce(
                 getComputedStyle(container).position !== "static",
                 "Please ensure that the container has a non-static position, like 'relative', 'fixed', or 'absolute' to ensure scroll offset is calculated correctly."


### PR DESCRIPTION
## Summary

When `scroll()` / `useScroll()` is used with the default `html` (document scrolling) container and a `target`, Motion currently emits:

> Please ensure that the container has a non-static position, like 'relative', 'fixed', or 'absolute' to ensure scroll offset is calculated correctly.

This is a false positive for the document scrolling element. The `offsetParent` walk inside `measure()` naturally resolves relative to the document for any target child of `<html>`/`<body>`, so static positioning is fine there. The warning is only meaningful for *custom* containers, where a non-static `position` is required to make the target's `offsetParent` chain terminate at the container.

The fix skips the warning when the container is `document.documentElement`, `document.scrollingElement`, or `document.body`.

Fixes #2880

## Test plan

- [x] New unit test `on-scroll-handler.test.ts` asserting the warning is suppressed for `document.documentElement` and still fires for a custom static container
- [x] `yarn build` passes
- [x] `yarn test` passes (780 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)