### PR TITLE
Support repeatDelay in animation sequences

### DIFF
--- a/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
+++ b/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
@@ -765,28 +765,9 @@ describe("createAnimationsFromSequence", () => {
                 )
             }
         )
-
-        test("warns when repeatDelay is set on a segment", () => {
-            createAnimationsFromSequence(
-                [
-                    [
-                        a,
-                        { x: [0, 100] },
-                        { duration: 1, repeat: 1, repeatDelay: 0.5 },
-                    ],
-                ],
-                undefined,
-                undefined,
-                { spring }
-            )
-
-            expect(warn).toHaveBeenCalledWith(
-                expect.stringContaining("repeatDelay is not supported")
-            )
-        })
     })
 
-    test.skip("It correctly adds repeatDelay between repeated keyframes", () => {
+    test("It correctly adds repeatDelay between repeated keyframes", () => {
         const animations = createAnimationsFromSequence(
             [
                 [

--- a/packages/framer-motion/src/animation/sequence/create.ts
+++ b/packages/framer-motion/src/animation/sequence/create.ts
@@ -199,21 +199,28 @@ export function createAnimationsFromSequence(
              * Segments can't express `repeat: Infinity` or very large
              * counts — they'd leave dead time after the segment or
              * explode the keyframe array. Ignore with a warning.
-             * `repeatDelay` is unsupported on segments.
              */
             if (repeat) {
                 warning(
                     repeat < MAX_REPEAT,
                     `Sequence segments can't repeat ${repeat} times — ignoring repeat option. Use a value below ${MAX_REPEAT} or apply repeat at the sequence level instead.`
                 )
-                warning(
-                    !repeatDelay,
-                    `repeatDelay is not supported on sequence segments and will be ignored.`
-                )
             }
 
             if (repeat && repeat < MAX_REPEAT) {
-                duration = calculateRepeatDuration(duration, repeat, 0)
+                /**
+                 * Express repeatDelay in units of a single iteration's duration
+                 * so it can be added to the per-iteration time offsets below
+                 * before they're normalized to 0-1.
+                 */
+                const repeatDelayUnits =
+                    duration > 0 ? repeatDelay / duration : 0
+
+                duration = calculateRepeatDuration(
+                    duration,
+                    repeat,
+                    repeatDelay
+                )
 
                 const originalKeyframes = [...valueKeyframesAsList]
                 const originalTimes = [...times]
@@ -256,6 +263,23 @@ export function createAnimationsFromSequence(
                         ? flippedKeyframes
                         : originalKeyframes
                     const iterEase = isFlipped ? flippedEases : originalEase
+                    const iterStartOffset =
+                        (repeatIndex + 1) * (1 + repeatDelayUnits)
+
+                    /**
+                     * If repeatDelay is set, hold the previous iteration's
+                     * final value through the delay by inserting a keyframe
+                     * at the moment the next iteration begins.
+                     */
+                    if (repeatDelayUnits > 0) {
+                        valueKeyframesAsList.push(
+                            valueKeyframesAsList[
+                                valueKeyframesAsList.length - 1
+                            ]
+                        )
+                        times.push(iterStartOffset)
+                        ease.push("linear")
+                    }
 
                     valueKeyframesAsList.push(...iterKeyframes)
 
@@ -265,7 +289,7 @@ export function createAnimationsFromSequence(
                         keyframeIndex++
                     ) {
                         times.push(
-                            originalTimes[keyframeIndex] + (repeatIndex + 1)
+                            originalTimes[keyframeIndex] + iterStartOffset
                         )
                         ease.push(
                             keyframeIndex === 0
@@ -278,7 +302,7 @@ export function createAnimationsFromSequence(
                     }
                 }
 
-                normalizeTimes(times, repeat)
+                normalizeTimes(times, repeat, repeatDelayUnits)
             }
 
             const targetTime = startTime + duration

--- a/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-repeat-duration.test.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-repeat-duration.test.ts
@@ -6,4 +6,10 @@ describe("calculateRepeatDuration", () => {
         expect(calculateRepeatDuration(1, 1, 0)).toEqual(2)
         expect(calculateRepeatDuration(1, 2, 0)).toEqual(3)
     })
+
+    test("It includes repeatDelay between iterations", () => {
+        expect(calculateRepeatDuration(1, 1, 0.5)).toEqual(2.5)
+        expect(calculateRepeatDuration(2, 3, 1)).toEqual(11)
+        expect(calculateRepeatDuration(1, 0, 0.5)).toEqual(1)
+    })
 })

--- a/packages/framer-motion/src/animation/sequence/utils/__tests__/normalize-times.test.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/__tests__/normalize-times.test.ts
@@ -7,4 +7,10 @@ describe("normalizeTimes", () => {
         normalizeTimes(times, repeat)
         expect(times).toEqual([0, 0.25, 0.5, 0.5, 0.75, 1])
     })
+
+    test("It accounts for repeatDelay between iterations", () => {
+        const times = [0, 1, 1.5, 1.5, 2.5]
+        normalizeTimes(times, 1, 0.5)
+        expect(times).toEqual([0, 0.4, 0.6, 0.6, 1])
+    })
 })

--- a/packages/framer-motion/src/animation/sequence/utils/calc-repeat-duration.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/calc-repeat-duration.ts
@@ -1,7 +1,7 @@
 export function calculateRepeatDuration(
     duration: number,
     repeat: number,
-    _repeatDelay: number
+    repeatDelay: number
 ): number {
-    return duration * (repeat + 1)
+    return duration * (repeat + 1) + repeatDelay * repeat
 }

--- a/packages/framer-motion/src/animation/sequence/utils/normalize-times.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/normalize-times.ts
@@ -3,9 +3,17 @@
  * if we have original times of [0, 0.5, 1] then our repeated times will
  * be [0, 0.5, 1, 1, 1.5, 2]. Loop over the times and scale them back
  * down to a 0-1 scale.
+ *
+ * `repeatDelayUnits` is the repeatDelay expressed in units of a single
+ * iteration's duration, so the total span equals `(repeat + 1) + repeat * repeatDelayUnits`.
  */
-export function normalizeTimes(times: number[], repeat: number): void {
+export function normalizeTimes(
+    times: number[],
+    repeat: number,
+    repeatDelayUnits = 0
+): void {
+    const totalUnits = repeat + 1 + repeat * repeatDelayUnits
     for (let i = 0; i < times.length; i++) {
-        times[i] = times[i] / (repeat + 1)
+        times[i] = times[i] / totalUnits
     }
 }


### PR DESCRIPTION
## Summary

- `createAnimationsFromSequence` ignored `repeatDelay` on segments with `repeat`. The total duration was computed as `duration * (repeat + 1)` regardless of the delay, and no hold keyframe was inserted between iterations — the value snapped straight from the end of one iteration into the start of the next, finishing too early.
- `calculateRepeatDuration` now adds `repeatDelay * repeat` to the total span, matching the semantics already used by `JSAnimation`.
- The repeat loop in `create.ts` inserts an extra "hold" keyframe at the end of each delay window so the previous iteration's final value is preserved through the delay before the next iteration's start keyframe snaps in.
- `normalizeTimes` takes the delay (expressed in iteration units) so per-iteration offsets are normalised across the full span rather than just `(repeat + 1)`.
- Un-skipped the existing test in `sequence/__tests__/index.test.ts` that documented the desired output, and added unit tests for the two updated utilities.

Fixes #3686

## Test plan

- [x] `yarn test` (all 781 unit tests pass)
- [x] `yarn build`
- [x] `It correctly adds repeatDelay between repeated keyframes` now passes; existing repeat tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)