### PR TITLE
Export framework-agnostic types from motion for non-React wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [Unreleased]
+
+### Added
+
+-   Export `DynamicAnimationOptions` (alias of `AnimationOptions`) and `MotionProps` (framework-agnostic alias of `MotionNodeOptions`) from `motion` to support typing wrappers in non-React frameworks (Svelte, Vue, etc.).
+
 ## [12.38.1] 2026-05-05
 
 ### Fixed

--- a/packages/motion-dom/src/animation/__tests__/public-types.test.ts
+++ b/packages/motion-dom/src/animation/__tests__/public-types.test.ts
@@ -1,0 +1,24 @@
+import type {
+    AnimationOptions,
+    AnimationPlaybackControls,
+    DOMKeyframesDefinition,
+    DynamicAnimationOptions,
+} from "../../"
+
+describe("motion-dom public type exports", () => {
+    it("exports DynamicAnimationOptions as a public type alias of AnimationOptions", () => {
+        const options: DynamicAnimationOptions = { duration: 0.5 }
+        const asAnimationOptions: AnimationOptions = options
+        expect(asAnimationOptions.duration).toBe(0.5)
+    })
+
+    it("exports DOMKeyframesDefinition", () => {
+        const keyframes: DOMKeyframesDefinition = { opacity: [0, 1] }
+        expect(keyframes.opacity).toEqual([0, 1])
+    })
+
+    it("exports AnimationPlaybackControls", () => {
+        const playback: AnimationPlaybackControls | null = null
+        expect(playback).toBeNull()
+    })
+})

--- a/packages/motion-dom/src/animation/types.ts
+++ b/packages/motion-dom/src/animation/types.ts
@@ -634,6 +634,12 @@ export type AnimationOptions =
               layout?: ValueTransition
           })
 
+/**
+ * Public alias matching the parameter name used in `animate()` signatures.
+ * @public
+ */
+export type DynamicAnimationOptions = AnimationOptions
+
 export interface TransformProperties {
     x?: AnyResolvedKeyframe
     y?: AnyResolvedKeyframe

--- a/packages/motion/src/index.ts
+++ b/packages/motion/src/index.ts
@@ -1,1 +1,8 @@
 export * from "framer-motion/dom"
+
+/**
+ * Re-export the framework-agnostic node options under the `MotionProps`
+ * name for users building wrappers in non-React frameworks (Svelte, Vue,
+ * etc.) who want the props type without pulling in `motion/react`.
+ */
+export type { MotionNodeOptions as MotionProps } from "framer-motion/dom"


### PR DESCRIPTION
## Summary

Surfaces framework-agnostic types under the `motion` package so authors building wrappers in non-React frameworks (Svelte, Vue, etc.) can type their wrappers without importing from `motion/react`.

- Adds `DynamicAnimationOptions` as a public type alias of `AnimationOptions` in `motion-dom`. This name was already used internally as a local alias in `animate()` signatures (e.g. `AnimationOptions as DynamicAnimationOptions`) but wasn't actually exported, so users couldn't import it.
- Re-exports `MotionNodeOptions` as `MotionProps` from `motion`'s vanilla entry. The React-specific `MotionProps` in `motion/react` is unchanged; the vanilla version aliases the framework-agnostic `MotionNodeOptions` so wrapper authors can write `import type { MotionProps } from 'motion'`.

## Why

Per #2870, vanilla wrapper authors were forced to import types from `motion/react`, pulling in React-specific type machinery they don't need. The framework-agnostic equivalents already existed (`MotionNodeOptions`, `AnimationOptions`) but under names users wouldn't recognise — and `DynamicAnimationOptions` wasn't exported at all despite being part of the public `animate()` API surface.

## Test plan

- [x] `yarn test` passes (778 tests)
- [x] `yarn build` produces correct `.d.ts` exports for both `motion` and `motion-dom`
- [x] New unit test in `motion-dom` verifies `DynamicAnimationOptions`, `DOMKeyframesDefinition`, and `AnimationPlaybackControls` are public type exports

Fixes #2870