### PR TITLE
Guard against MotionValue type re-inlining in bundled .d.ts (#2887)

### DIFF
--- a/packages/framer-motion/scripts/check-bundle.js
+++ b/packages/framer-motion/scripts/check-bundle.js
@@ -12,8 +12,11 @@ if (file.includes(`<reference types="react" />`)) {
 
 /**
  * Verify every "types" entry in package.json exports points to a file that
- * exists, and that the bundled .d.ts file is self-contained (no relative
- * imports of internal chunks). Issue #2900.
+ * exists, that the bundle is self-contained (no relative imports of internal
+ * chunks — #2900), and that it doesn't inline its own `declare class
+ * MotionValue` (two inlined declarations have nominally-distinct `private
+ * current` fields, breaking assignability between entry points like
+ * `motion/react` and `motion/react-m` — #2887).
  */
 for (const [name, entry] of Object.entries(pkg.exports)) {
     if (!entry || typeof entry !== "object" || !entry.types) continue
@@ -30,6 +33,12 @@ for (const [name, entry] of Object.entries(pkg.exports)) {
     if (relativeImport) {
         throw new Error(
             `Types file for "${name}" (${entry.types}) contains a relative import (${relativeImport[1]}) — types must be bundled into a single self-contained file`
+        )
+    }
+
+    if (/^declare class MotionValue\b/m.test(contents)) {
+        throw new Error(
+            `Types file for "${name}" (${entry.types}) inlines \`declare class MotionValue\` instead of importing it from motion-dom — this breaks MotionValue assignability across entry points (#2887)`
         )
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #2887, which reports that `MotionValue<T>` imported from `motion/react` is not assignable to a slot expecting `MotionValue<T>` from `motion/react-m`. TypeScript reports `Types have separate declarations of a private property 'current'`.
- Root cause: when `rollup-plugin-dts` bundled the `m` entry, it inlined its own `declare class MotionValue` instead of importing it from `motion-dom`. TypeScript treats `private` fields nominally, so the inlined `MotionValue` and the canonical one in `motion-dom` end up as distinct, mutually-incompatible types.
- The bug no longer reproduces against current `main` — `dist/m.d.ts` now imports `MotionValue` from `motion-dom`, so the two entry points share a single class declaration. There is no source-code change required to fix the issue.
- This PR adds a guard to the existing post-build assertion script (`packages/framer-motion/scripts/check-bundle.js`) so the regression is caught at build time if a future rollup or `rollup-plugin-dts` change re-inlines `MotionValue` into any of the bundled entry `.d.ts` files (`m`, `mini`, `dom`, `dom-mini`, `debug`, `projection`).

## Reproduction (against npm `motion@11.11.17`)

```ts
import type { MotionValue } from 'motion/react'
import { div } from 'motion/react-m'

div({ style: { x: 5 as unknown as MotionValue<number> } })
// TS2322: Types have separate declarations of a private property 'current'.
```

The same snippet against the locally-built `motion@12.38.0` (this branch) compiles cleanly.

## Test plan

- [x] `yarn build` (turborepo, all 8 tasks succeed)
- [x] `yarn test` (778 passed, 10 skipped, 0 failed)
- [x] Manually verified the new check rejects an `m.d.ts` that contains `declare class MotionValue<V> { private current: V }` and accepts the current build output.
- [x] Built `motion` locally, packed via `npm pack`, installed into a scratch project with `exactOptionalPropertyTypes: true` and confirmed the issue's snippet typechecks.