### PR TITLE
Add domAnimations alias for domAnimation export

### DIFF
--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -36,7 +36,10 @@ export { useUnmountEffect } from "./utils/use-unmount-effect"
 /**
  * Features
  */
-export { domAnimation } from "./render/dom/features-animation"
+export {
+    domAnimation,
+    domAnimation as domAnimations,
+} from "./render/dom/features-animation"
 export { domMax } from "./render/dom/features-max"
 export { domMin } from "./render/dom/features-min"
 

--- a/packages/framer-motion/src/motion/__tests__/lazy.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/lazy.test.tsx
@@ -1,5 +1,6 @@
 import { motionValue } from "motion-dom"
 import { LazyMotion, domAnimation, domMax, m, motion } from "../.."
+import * as motionExports from "../.."
 import { render } from "../../jest.setup"
 
 describe("Lazy feature loading", () => {
@@ -23,6 +24,35 @@ describe("Lazy feature loading", () => {
         })
 
         return expect(promise).resolves.not.toBe(20)
+    })
+
+    test("Exports domAnimations as alias for domAnimation", () => {
+        expect((motionExports as any).domAnimations).toBeDefined()
+        expect((motionExports as any).domAnimations).toBe(domAnimation)
+    })
+
+    test("Does animate with synchronously-loaded domAnimations alias", async () => {
+        const domAnimations = (motionExports as any).domAnimations
+        const promise = new Promise((resolve) => {
+            const x = motionValue(0)
+            const onComplete = () => resolve(x.get())
+
+            const Component = () => (
+                <LazyMotion features={domAnimations}>
+                    <m.div
+                        animate={{ x: 20 }}
+                        transition={{ duration: 0.01 }}
+                        style={{ x }}
+                        onAnimationComplete={onComplete}
+                    />
+                </LazyMotion>
+            )
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        return expect(promise).resolves.toBe(20)
     })
 
     test("Does animate with synchronously-loaded domAnimation", async () => {


### PR DESCRIPTION
## Summary

- Adds `domAnimations` as an alias export for `domAnimation` to match the name used in the [motion documentation](https://motion.dev/docs/react-lazy-motion)
- The `motion/react` subpath also picks this up automatically via its `export *` re-export from `framer-motion`

## Bug

Per #2856, the docs example for async-loading LazyMotion references `domAnimations` (plural):

```js
// features.js
import { domAnimation } from "motion/react"
export default domAnimations
```

…but no such export exists, so users following the docs hit a TypeScript error. The established export is `domAnimation` (singular), so renaming would be a breaking change. Adding `domAnimations` as an additive alias resolves the mismatch without breaking any existing consumer.

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (794 tests, 7 skipped)
- [x] New unit tests in `lazy.test.tsx` verify (a) `domAnimations` is exported and identical to `domAnimation`, and (b) it works as a `LazyMotion` features bundle
- [x] Confirmed both new tests fail before the fix and pass after

Fixes #2856

🤖 Generated with [Claude Code](https://claude.com/claude-code)