### PR TITLE
Fix useScroll falling back to window scroll when ref hydrates late

### DIFF
--- a/dev/react/src/tests/use-scroll-target-late-ref.tsx
+++ b/dev/react/src/tests/use-scroll-target-late-ref.tsx
@@ -1,0 +1,72 @@
+import { useMotionValueEvent, useScroll } from "framer-motion"
+import * as React from "react"
+import { useEffect, useRef, useState } from "react"
+import * as ReactDOMClient from "react-dom/client"
+
+/**
+ * Reproduction for #2851 — useScroll target ref hydrated after the hook's
+ * own effects run (e.g. via querySelector in a useEffect declared after
+ * useScroll). Before the fix, useScroll fell back to the whole-window scroll
+ * because target.current was still null when its useEffect ran.
+ *
+ * The actual reproduction is rendered in a fresh ReactDOM root so it isn't
+ * wrapped by the dev harness's StrictMode — StrictMode's double-mount in dev
+ * masks the bug because the second mount sees the hydrated ref.
+ */
+export const App = () => {
+    const containerRef = useRef<HTMLDivElement | null>(null)
+
+    useEffect(() => {
+        if (!containerRef.current) return
+        const root = ReactDOMClient.createRoot(containerRef.current)
+        root.render(<Repro />)
+        return () => {
+            queueMicrotask(() => root.unmount())
+        }
+    }, [])
+
+    return <div ref={containerRef} />
+}
+
+const Repro = () => {
+    const targetRef = useRef<HTMLDivElement | null>(null)
+
+    const { scrollYProgress } = useScroll({
+        target: targetRef,
+        offset: ["start end", "end start"],
+    })
+
+    useEffect(() => {
+        targetRef.current = document.querySelector(
+            "#target"
+        ) as HTMLDivElement | null
+    }, [])
+
+    const [progress, setProgress] = useState(0)
+    useMotionValueEvent(scrollYProgress, "change", setProgress)
+
+    return (
+        <>
+            <div style={topSpacer} />
+            <div id="target" style={targetStyle} />
+            <div style={bottomSpacer} />
+            <div id="progress" style={progressStyle}>
+                {progress.toFixed(4)}
+            </div>
+        </>
+    )
+}
+
+const topSpacer: React.CSSProperties = { height: "200vh" }
+const bottomSpacer: React.CSSProperties = { height: "100vh" }
+const targetStyle: React.CSSProperties = {
+    height: "100vh",
+    background: "red",
+}
+const progressStyle: React.CSSProperties = {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    background: "white",
+    zIndex: 10,
+}

--- a/dev/react/src/tests/use-scroll-target-late-ref.tsx
+++ b/dev/react/src/tests/use-scroll-target-late-ref.tsx
@@ -20,6 +20,8 @@ export const App = () => {
         if (!containerRef.current) return
         const root = ReactDOMClient.createRoot(containerRef.current)
         root.render(<Repro />)
+        // Defer unmount: React 18 errors when a root is unmounted
+        // synchronously from another root's effect cleanup.
         return () => {
             queueMicrotask(() => root.unmount())
         }
@@ -37,9 +39,7 @@ const Repro = () => {
     })
 
     useEffect(() => {
-        targetRef.current = document.querySelector(
-            "#target"
-        ) as HTMLDivElement | null
+        targetRef.current = document.querySelector<HTMLDivElement>("#target")
     }, [])
 
     const [progress, setProgress] = useState(0)

--- a/packages/framer-motion/cypress/integration/use-scroll-target-late-ref.ts
+++ b/packages/framer-motion/cypress/integration/use-scroll-target-late-ref.ts
@@ -1,19 +1,9 @@
 describe("useScroll with target ref hydrated after useScroll's own effects", () => {
     it("Tracks the target element, not the whole window", () => {
-        // Page layout (viewport = 500px tall):
-        //   top spacer  : 200vh = 1000px
-        //   target      : 100vh = 500px
-        //   bottom spacer: 100vh = 500px
-        //
-        // Total content = 2000px, scroll length = 1500px.
-        //
-        // With target ref (offset ["start end", "end start"]):
-        //   progress = 0 when scrollY <= 500 (target.top hits viewport.bottom)
-        //   progress = 1 when scrollY = 1500
-        //
-        // Without target ref (the bug — falls back to whole window):
-        //   progress = scrollY / 1500
-        //   At scrollY = 400, progress ≈ 0.267
+        // Target sits 1000px below the top in a 2000px-tall page (500px
+        // viewport). At scrollY=400 the target is still off-screen, so
+        // progress must be ~0. If useScroll falls back to whole-window
+        // tracking, progress is 400/1500 ≈ 0.267.
         cy.visit("?test=use-scroll-target-late-ref")
             .viewport(100, 500)
             .wait(200)
@@ -22,11 +12,7 @@ describe("useScroll with target ref hydrated after useScroll's own effects", () 
             .wait(500)
             .get("#progress")
             .then(([$el]: any) => {
-                const progress = parseFloat($el.innerText)
-                // Target hasn't entered the viewport yet, so progress should
-                // still be 0 — anything noticeably above 0 means useScroll is
-                // measuring the whole window.
-                expect(progress).to.be.lessThan(0.05)
+                expect(parseFloat($el.innerText)).to.be.lessThan(0.05)
             })
     })
 })

--- a/packages/framer-motion/cypress/integration/use-scroll-target-late-ref.ts
+++ b/packages/framer-motion/cypress/integration/use-scroll-target-late-ref.ts
@@ -1,0 +1,32 @@
+describe("useScroll with target ref hydrated after useScroll's own effects", () => {
+    it("Tracks the target element, not the whole window", () => {
+        // Page layout (viewport = 500px tall):
+        //   top spacer  : 200vh = 1000px
+        //   target      : 100vh = 500px
+        //   bottom spacer: 100vh = 500px
+        //
+        // Total content = 2000px, scroll length = 1500px.
+        //
+        // With target ref (offset ["start end", "end start"]):
+        //   progress = 0 when scrollY <= 500 (target.top hits viewport.bottom)
+        //   progress = 1 when scrollY = 1500
+        //
+        // Without target ref (the bug — falls back to whole window):
+        //   progress = scrollY / 1500
+        //   At scrollY = 400, progress ≈ 0.267
+        cy.visit("?test=use-scroll-target-late-ref")
+            .viewport(100, 500)
+            .wait(200)
+
+        cy.scrollTo(0, 400)
+            .wait(500)
+            .get("#progress")
+            .then(([$el]: any) => {
+                const progress = parseFloat($el.innerText)
+                // Target hasn't entered the viewport yet, so progress should
+                // still be 0 — anything noticeably above 0 means useScroll is
+                // measuring the whole window.
+                expect(progress).to.be.lessThan(0.05)
+            })
+    })
+})

--- a/packages/framer-motion/src/value/use-scroll.ts
+++ b/packages/framer-motion/src/value/use-scroll.ts
@@ -142,7 +142,13 @@ export function useScroll({
     }, [start])
 
     useEffect(() => {
-        if (needsStart.current) {
+        if (!needsStart.current) return
+
+        // The ref hasn't been hydrated yet — most likely it's set by an effect
+        // declared after useScroll (or in a parent component). Defer start to
+        // a microtask so those effects have a chance to run first.
+        let cleanup: VoidFunction | undefined
+        const tryStart = () => {
             invariant(
                 !isRefPending(container),
                 "Container ref is defined but not hydrated",
@@ -153,9 +159,15 @@ export function useScroll({
                 "Target ref is defined but not hydrated",
                 "use-scroll-ref"
             )
-            return start()
-        } else {
-            return
+            if (!isRefPending(container) && !isRefPending(target)) {
+                cleanup = start()
+            }
+        }
+        microtask.read(tryStart)
+
+        return () => {
+            cancelMicrotask(tryStart)
+            cleanup?.()
         }
     }, [start])
 

--- a/packages/framer-motion/src/value/use-scroll.ts
+++ b/packages/framer-motion/src/value/use-scroll.ts
@@ -144,24 +144,23 @@ export function useScroll({
     useEffect(() => {
         if (!needsStart.current) return
 
-        // The ref hasn't been hydrated yet — most likely it's set by an effect
-        // declared after useScroll (or in a parent component). Defer start to
-        // a microtask so those effects have a chance to run first.
+        // Defer to a microtask so any sibling/parent effect that hydrates the
+        // ref has a chance to run first.
         let cleanup: VoidFunction | undefined
         const tryStart = () => {
+            const containerPending = isRefPending(container)
+            const targetPending = isRefPending(target)
             invariant(
-                !isRefPending(container),
+                !containerPending,
                 "Container ref is defined but not hydrated",
                 "use-scroll-ref"
             )
             invariant(
-                !isRefPending(target),
+                !targetPending,
                 "Target ref is defined but not hydrated",
                 "use-scroll-ref"
             )
-            if (!isRefPending(container) && !isRefPending(target)) {
-                cleanup = start()
-            }
+            if (!containerPending && !targetPending) cleanup = start()
         }
         microtask.read(tryStart)
 


### PR DESCRIPTION
## Summary

`useScroll` was falling back to whole-window scroll measurement when the
target/container ref was hydrated by an effect declared *after*
`useScroll` (a common pattern when using `querySelector` or when the ref
is owned by a parent component).

When that happened, the layout effect would set `needsStart=true`, and
the follow-up `useEffect` would invoke `start()` synchronously — but
React fires effects in declaration order, so the ref-hydrating effect
hadn't run yet. `start()` would then call `scroll()` with
`target: undefined`, falling back to the document scrolling element.

In dev builds the bug was masked by StrictMode's double-mount (the
second mount sees the now-hydrated ref), which is why it reproduced in
local production-style environments but not in some sandboxes.

## Fix

Defer the `start()` invocation in the fallback `useEffect` to a
`microtask`, mirroring the pattern already used in
`makeAccelerateConfig`. By the time the microtask runs, every other
effect from the current commit has completed, including any
sibling/parent effect that hydrates the ref.

Fixes #2851

## Test plan

- [x] New Cypress spec `use-scroll-target-late-ref.ts` reproduces the
      issue (renders the repro inside a fresh ReactDOM root to bypass
      the dev harness's StrictMode double-mount, since StrictMode hides
      the bug). Fails on `main`, passes with the fix.
- [x] Spec passes on React 18 and React 19 dev harnesses.
- [x] Existing scroll Cypress specs still pass
      (`scroll.ts`, `scroll-accelerate.ts`, `scroll-target-transform.ts`,
      `scroll-view-timeline.ts`,
      `scroll-view-timeline-transformed-parent.ts`).
- [x] Full unit test suite passes (`yarn test` — 792 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)