### PR TITLE
Fix variant keyframe animations not re-running when keyframes match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## Unreleased
+
+### Fixed
+
+-   Variants: Re-run keyframe animations when switching between variants that share identical keyframe arrays for a value.
+
 ## [12.39.0] 2026-05-05
 
 ### Added

--- a/packages/framer-motion/src/motion/__tests__/transition-keyframes.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/transition-keyframes.test.tsx
@@ -85,7 +85,7 @@ describe("keyframes transition", () => {
         expect(xResult).toBe(100)
     })
 
-    test("keyframes animation doesn't rerun when variants change and keyframes are the same", async () => {
+    test("keyframes animation reruns when variants change and keyframes are the same", async () => {
         const xResult = await new Promise((resolve) => {
             const x = motionValue(0)
             const Component = ({ animate }: any) => {
@@ -109,7 +109,45 @@ describe("keyframes transition", () => {
             setTimeout(() => resolve(x.get()), 50)
         })
 
-        expect(xResult).toBe(100)
+        expect(xResult).toBe(50)
+    })
+
+    test("issue #2855: keyframes with shared values across variants rerun on each change", async () => {
+        const z = motionValue(0)
+        const updateCounts: number[] = []
+
+        const Component = ({ animate }: any) => (
+            <motion.div
+                animate={animate}
+                variants={{
+                    start: { rotateZ: [0, 10, 0] },
+                    end: { rotateZ: [0, 10, 0] },
+                }}
+                transition={{ duration: 0.05, ease: "linear" }}
+                style={{ rotateZ: z }}
+            />
+        )
+
+        const recordAndReset = async () => {
+            let count = 0
+            const unsubscribe = z.on("change", () => count++)
+            await new Promise((r) => setTimeout(r, 100))
+            unsubscribe()
+            updateCounts.push(count)
+        }
+
+        const { rerender } = render(<Component animate="start" />)
+        await recordAndReset()
+
+        rerender(<Component animate="end" />)
+        await recordAndReset()
+
+        rerender(<Component animate="start" />)
+        await recordAndReset()
+
+        expect(updateCounts[0]).toBeGreaterThan(0)
+        expect(updateCounts[1]).toBeGreaterThan(0)
+        expect(updateCounts[2]).toBeGreaterThan(0)
     })
 
     test("times works as expected", async () => {

--- a/packages/motion-dom/src/render/utils/animation-state.ts
+++ b/packages/motion-dom/src/render/utils/animation-state.ts
@@ -300,7 +300,8 @@ export function createAnimationState(visualElement: any): AnimationState {
                  */
                 let valueHasChanged = false
                 if (isKeyframesTarget(next) && isKeyframesTarget(prev)) {
-                    valueHasChanged = !shallowCompare(next, prev)
+                    valueHasChanged =
+                        !shallowCompare(next, prev) || variantDidChange
                 } else {
                     valueHasChanged = next !== prev
                 }


### PR DESCRIPTION
## Summary

When switching between variants that share an identical keyframe array for a value, the animation only ran on the first variant transition. Subsequent variant changes left the value static.

```jsx
const variants = {
  start: { rotateZ: [0, 10, 0] },
  end:   { rotateZ: [0, 10, 0] },
};
// First click animates rotateZ. Subsequent clicks do not.
```

## Cause

Variant change detection in `motion-dom`'s `animation-state.ts` shallow-compared keyframe arrays:

```ts
if (isKeyframesTarget(next) && isKeyframesTarget(prev)) {
    valueHasChanged = !shallowCompare(next, prev)
}
```

Two arrays of `[0, 10, 0]` shallow-compare as equal, so `valueHasChanged` was `false` and the value was added to `protectedKeys`, blocking the animation. This was a regression from #2466 — the prior code had a `|| variantDidChange` escape hatch which was inadvertently dropped, and the regression test was inverted at the same time.

## Fix

Restore `|| variantDidChange` so that when the active variant label actually changes, keyframe arrays re-trigger their animation regardless of array equality. The original #1576 case (inline variants re-rendering with the same active label) still works correctly because `variantDidChange` is `false` when the variant label is unchanged.

The test added in #2466 that documented the regression has been reverted to its pre-#2466 form (`reruns` / expected `x=50`), and a new test using the issue's `[0, n, 0]` reproduction has been added.

Fixes #2855

## Test plan

- [x] Unit test reproducing #2855 fails on `main`, passes with this fix
- [x] Inverted test from #2466 reverted; passes with this fix
- [x] Full unit test suite passes (`yarn test` — 793 passing)
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)