### PR TITLE
Fix Reorder breaking inside motion.div with scale: "100%" (#2857)

### DIFF
--- a/dev/react/src/tests/reorder-scaled-parent.tsx
+++ b/dev/react/src/tests/reorder-scaled-parent.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react"
+import { motion, Reorder, useMotionValue } from "framer-motion"
+
+const initialItems = ["Tomato", "Cucumber", "Cheese", "Lettuce"]
+
+const Item = ({ item }: { item: string }) => {
+    const y = useMotionValue(0)
+    return (
+        <Reorder.Item value={item} id={item} style={{ y }}>
+            <span id={`label-${item}`}>{item}</span>
+        </Reorder.Item>
+    )
+}
+
+export const App = () => {
+    const [items, setItems] = useState(initialItems)
+    const params = new URLSearchParams(window.location.search)
+    const scale = params.get("scale") || "100%"
+
+    return (
+        <motion.div
+            id="scaled-parent"
+            initial={{ scale }}
+            style={{ width: 300 }}
+        >
+            <Reorder.Group
+                axis="y"
+                onReorder={setItems}
+                values={items}
+                style={list}
+            >
+                {items.map((item) => (
+                    <Item key={item} item={item} />
+                ))}
+            </Reorder.Group>
+            <style>{styles}</style>
+        </motion.div>
+    )
+}
+
+const list: React.CSSProperties = {
+    listStyle: "none",
+    padding: 0,
+    margin: 0,
+    width: 300,
+}
+
+const styles = `
+body {
+  margin: 0;
+  padding: 0;
+  background: #ffaa00;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  font-family: sans-serif;
+}
+
+li {
+  background: white;
+  border-radius: 5px;
+  margin-bottom: 10px;
+  padding: 15px 18px;
+  list-style: none;
+  cursor: grab;
+}
+`

--- a/packages/framer-motion/cypress/integration/reorder-scaled-parent.ts
+++ b/packages/framer-motion/cypress/integration/reorder-scaled-parent.ts
@@ -1,0 +1,40 @@
+describe("Reorder inside a parent with scale transform (#2857)", () => {
+    it("Element follows the cursor 1:1 with parent scale: '100%'", () => {
+        cy.visit("?test=reorder-scaled-parent")
+            .wait(200)
+            .get("#Tomato")
+            .then(($el: any) => {
+                const startRect = ($el[0] as HTMLElement).getBoundingClientRect()
+                const startMidX = startRect.left + startRect.width / 2
+                const startMidY = startRect.top + startRect.height / 2
+
+                cy.wrap($el)
+                    .trigger("pointerdown", startMidX, startMidY, {
+                        force: true,
+                    })
+                    .wait(50)
+                    .trigger("pointermove", startMidX, startMidY + 5, {
+                        force: true,
+                    })
+                    .wait(50)
+                    .trigger("pointermove", startMidX, startMidY + 30, {
+                        force: true,
+                    })
+                    .wait(50)
+                    .then(([item]: any) => {
+                        const movedRect = (
+                            item as HTMLElement
+                        ).getBoundingClientRect()
+                        const movedMidY =
+                            movedRect.top + movedRect.height / 2
+                        const screenDelta = movedMidY - startMidY
+
+                        expect(screenDelta).to.be.greaterThan(20)
+                        expect(screenDelta).to.be.lessThan(40)
+                    })
+                    .trigger("pointerup", startMidX, startMidY + 30, {
+                        force: true,
+                    })
+            })
+    })
+})

--- a/packages/motion-dom/src/projection/utils/__tests__/has-transform.test.ts
+++ b/packages/motion-dom/src/projection/utils/__tests__/has-transform.test.ts
@@ -1,0 +1,39 @@
+import { hasScale, hasTransform } from "../has-transform"
+
+describe("hasScale", () => {
+    it("returns false for identity number scales", () => {
+        expect(hasScale({})).toBe(false)
+        expect(hasScale({ scale: 1 })).toBe(false)
+        expect(hasScale({ scaleX: 1, scaleY: 1 })).toBe(false)
+    })
+
+    it("returns true for non-identity number scales", () => {
+        expect(hasScale({ scale: 0.5 })).toBe(true)
+        expect(hasScale({ scaleX: 2 })).toBe(true)
+    })
+
+    it("returns false for percentage strings that resolve to identity (#2857)", () => {
+        // CSS scale(100%) is equivalent to scale(1) — visual no-op. The
+        // projection system must not treat it as a non-identity transform,
+        // otherwise the string poisons the layout box math (NaN) and breaks
+        // drag/Reorder when wrapped in motion.div.
+        expect(hasScale({ scale: "100%" })).toBe(false)
+        expect(hasScale({ scaleX: "100%", scaleY: "100%" })).toBe(false)
+    })
+
+    it("returns false for numeric strings that resolve to identity", () => {
+        expect(hasScale({ scale: "1" })).toBe(false)
+        expect(hasScale({ scale: "1.0" })).toBe(false)
+    })
+
+    it("returns true for percentage strings that don't resolve to identity", () => {
+        expect(hasScale({ scale: "50%" })).toBe(true)
+        expect(hasScale({ scale: "200%" })).toBe(true)
+    })
+})
+
+describe("hasTransform", () => {
+    it("returns falsy when only scale: '100%' is set (#2857)", () => {
+        expect(hasTransform({ scale: "100%" })).toBeFalsy()
+    })
+})

--- a/packages/motion-dom/src/projection/utils/has-transform.ts
+++ b/packages/motion-dom/src/projection/utils/has-transform.ts
@@ -2,7 +2,12 @@ import { type AnyResolvedKeyframe } from "../../animation/types"
 import { ResolvedValues } from "../../render/types"
 
 function isIdentityScale(scale: AnyResolvedKeyframe | undefined) {
-    return scale === undefined || scale === 1
+    if (scale === undefined || scale === 1) return true
+    if (typeof scale !== "string") return false
+    // CSS scale() treats 100% as 1; anything else is a no-op string that
+    // would NaN-poison the layout box if applied.
+    const parsed = parseFloat(scale)
+    return scale.endsWith("%") ? parsed === 100 : parsed === 1
 }
 
 export function hasScale({ scale, scaleX, scaleY }: ResolvedValues) {


### PR DESCRIPTION
## Summary

`motion.div` with `initial={{ scale: \"100%\" }}` stored the literal string `\"100%\"` in `latestValues`. `isIdentityScale` only treated the number `1` (and `undefined`) as identity, so `hasScale` reported the parent as scaled. The projection system then multiplied the raw string into layout box math (`scalePoint(point, \"100%\", origin)` ⇒ `NaN`), poisoning the descendant `Reorder.Item`'s layout box and making it jump wildly during drag.

CSS already treats `scale(100%)` and `scale(1)` as the same value, so the projection system should agree.

## Cause

`packages/motion-dom/src/projection/utils/has-transform.ts`:
```ts
function isIdentityScale(scale) {
    return scale === undefined || scale === 1
}
```
String identity values like `\"1\"`, `\"1.0\"`, and `\"100%\"` were missed, causing `hasScale`/`hasTransform` to return true and triggering the projection's transform-application path.

## Fix

Recognize percentage strings (and numeric strings) that resolve to identity. For `\"100%\"`, `parseFloat` returns `100`, which combined with the `%` suffix represents `1.0`.

## Test plan

- [x] Reproduction from the linked CodeSandbox added as Cypress test `reorder-scaled-parent.ts` — fails before the fix (item moved 209px when cursor moved 30px), passes after.
- [x] Unit tests for `hasScale`/`hasTransform` covering numeric, string, and percent inputs.
- [x] Cypress passes on React 18 and React 19.
- [x] Existing `drag-to-reorder`, `drag-scaled-parent`, `reorder-axis-change`, `animate-presence-reorder` continue to pass.
- [x] Full unit suite (792 tests) passes.

Fixes #2857

🤖 Generated with [Claude Code](https://claude.com/claude-code)