### PR TITLE
Animate motion.meta attributes

### DIFF
--- a/packages/framer-motion/src/motion/__tests__/meta.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/meta.test.tsx
@@ -1,0 +1,25 @@
+import { createRef } from "react"
+import { motion } from "../.."
+import { render } from "../../jest.setup"
+
+describe("motion.meta", () => {
+    test("animates content attribute", async () => {
+        const element = await new Promise<HTMLMetaElement>((resolve) => {
+            const ref = createRef<HTMLMetaElement>()
+            const Component = () => (
+                <motion.meta
+                    ref={ref}
+                    name="theme-color"
+                    initial={{ content: "rgba(255, 0, 0, 1)" }}
+                    animate={{ content: "rgba(0, 0, 255, 1)" }}
+                    transition={{ duration: 0.01 }}
+                    onAnimationComplete={() => resolve(ref.current!)}
+                />
+            )
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(element.getAttribute("content")).toBe("rgba(0, 0, 255, 1)")
+    })
+})

--- a/packages/motion-dom/src/render/html/utils/render.ts
+++ b/packages/motion-dom/src/render/html/utils/render.ts
@@ -9,10 +9,20 @@ export function renderHTML(
 ) {
     const elementStyle = element.style
 
+    /**
+     * Elements like <meta> have no rendered styles, so animated values
+     * are applied as attributes (e.g. `content` on <meta name="theme-color">).
+     */
+    const renderAsAttrs = element.tagName === "META"
+
     let key: string
     for (key in style) {
-        // CSSStyleDeclaration has [index: number]: string; in the types, so we use that as key type.
-        elementStyle[key as unknown as number] = style[key] as string
+        if (renderAsAttrs) {
+            element.setAttribute(key, style[key] as string)
+        } else {
+            // CSSStyleDeclaration has [index: number]: string; in the types, so we use that as key type.
+            elementStyle[key as unknown as number] = style[key] as string
+        }
     }
 
     // Write projection styles directly to element style


### PR DESCRIPTION
## Summary

- Apply animated values on `<motion.meta>` elements as DOM attributes (via `setAttribute`) rather than inline styles, so animating `content` on `<motion.meta name="theme-color" />` actually updates the rendered theme color.
- Meta tags are not visually rendered, so the previous style-only render path produced no observable update — animating `content` between two colors had no effect.
- Adds a Jest test in `framer-motion/src/motion/__tests__/meta.test.tsx` that animates `content` from one rgba color to another and asserts the final attribute value on the element.

## Bug

```tsx
<motion.meta
  name="theme-color"
  initial={{ content: "rgba(255, 0, 0, 1)" }}
  animate={{ content: "rgba(0, 0, 255, 1)" }}
/>
```

Previously, the animated value was written to `element.style.content`, which has no effect on a `<meta>` tag's `content` attribute. The browser's theme color never updated.

## Fix

In `renderHTML`, detect `element.tagName === "META"` and route the built `style` values through `element.setAttribute(key, value)` instead of `element.style[key] = value`.

Fixes #3100

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn test` — all 794 tests pass, including the new `motion.meta` test
- [x] New unit test fails before the fix (`content` attribute is `null`) and passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)