### PR TITLE
Investigate #3407: same root cause as #3265, fixed in #3593

### DIFF
--- a/packages/motion-dom/src/value/__tests__/follow-value-framerate.test.ts
+++ b/packages/motion-dom/src/value/__tests__/follow-value-framerate.test.ts
@@ -24,7 +24,7 @@ function processFrame(timestamp: number) {
     frameData.isProcessing = false
 }
 
-describe("Spring follow at different frame rates (issue #3265)", () => {
+describe("Spring follow at different frame rates (issues #3265, #3407)", () => {
     beforeEach(() => {
         MotionGlobalConfig.useManualTiming = true
         frameData.timestamp = 0


### PR DESCRIPTION
Fixes #3407 (recommend closing as already fixed)

## Summary

Issue #3407 reports a Chrome-only spring animation bug where a `useSpring`-driven cursor follower feels "stuck" and resists orbiting the cursor. After investigation, this appears to be the same root cause as #3265, which was already fixed by PR #3593 (commit `e93102089`, shipped in v12.35.2 and later).

This PR is a draft for tracking purposes — no fix is required. The only diff is a test rename annotating that #3407 is covered by the existing regression gate at `packages/motion-dom/src/value/__tests__/follow-value-framerate.test.ts`.

## Background

- **2026-01-22** — Issue #3407 reported. Maintainer asked the reporter to test `12.29.1-alpha.0`. That alpha did not yet contain the velocity-preservation fix.
- **2026-03-02..03** — A previous attempt (#3577) added a `sampleAt`/`canSampleVelocity` API to `JSAnimation` to read pre-stop velocity via a 5ms finite difference. Closed without merge.
- **2026-03-04** — PR #3593 landed commit `e93102089` ("Fix laggy spring animations at high refresh rates (240hz)") which addresses the same root cause more cleanly: it adds `JSAnimation.getGeneratorVelocity()` (analytical derivative from the spring formula) and reads it in `attachFollow.startAnimation()` before stopping the active animation. It also stabilises the `frame.postRender` reference so multiple per-frame events deduplicate.

## Why #3407 and #3265 are the same bug

Both reports trace to:

> `attachFollow`'s `startAnimation()` reads `value.getVelocity()` after calling `stopAnimation()`. When the spring is interrupted after only one frame (Chrome vsync-aligned `mousemove`, or any 240hz display), `getVelocity()` returns a cross-animation finite difference that collapses to ~0, so the spring restarts with no velocity and feels stuck.

Current `follow-value.ts` already does the right thing:

```ts
const velocity = activeAnimation
    ? activeAnimation.getGeneratorVelocity()
    : value.getVelocity()
```

## Verification

`packages/motion-dom/src/value/__tests__/follow-value-framerate.test.ts` simulates a moving target at 60hz vs 240hz with vsync-aligned interruptions every frame:

- With the current fix, 240hz tracks within 10% of 60hz.
- Reverting the `getGeneratorVelocity()` line back to `value.getVelocity()` drops the ratio to ~0.78 — the test fails for the right reason and reproduces the "stuck" behaviour described in #3407.

## Recommendation

Ask the reporter to upgrade to v12.35.2 or later (current latest: v12.38.0). If they still see the regression on the latest version, reopen with a fresh CodeSandbox so we have a real repro to chase.

## Test plan

- [x] `follow-value-framerate.test.ts` passes against current `main`
- [x] `follow-value-framerate.test.ts` fails when `getGeneratorVelocity()` is reverted to `value.getVelocity()` (ratio 0.78 < 0.9)
- [x] `yarn build` succeeds
- [x] `yarn test` — 793 passed, 7 skipped, 0 failed