### PR TITLE
Fix AnimatePresence stuck exit when motion child unmounts mid-exit

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../context/PresenceContext"
 import { VariantLabels } from "../../motion/types"
 import { useConstant } from "../../utils/use-constant"
+import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
 import { PopChild } from "./PopChild"
 
 interface PresenceChildProps {
@@ -39,14 +40,18 @@ export const PresenceChild = ({
     const id = useId()
 
     /**
-     * Track the latest `isPresent` and `onExitComplete` so the cleanup
-     * returned from `register` can read up-to-date values. The cleanup
-     * fires whenever a motion child unmounts; if it unmounts during exit
-     * and was the last registered child, we need to fire `onExitComplete`
-     * here because the parent useEffect won't re-run.
+     * Track the latest committed `isPresent` and `onExitComplete` so the
+     * cleanup returned from `register` can read up-to-date values when a
+     * motion child unmounts mid-exit. The ref is written in a layout
+     * effect — not during render — so discarded concurrent renders never
+     * leave it pointing at uncommitted state.
      */
-    const latest = useRef({ isPresent, onExitComplete })
-    latest.current = { isPresent, onExitComplete }
+    const isPresentRef = useRef(isPresent)
+    const onExitCompleteRef = useRef(onExitComplete)
+    useIsomorphicLayoutEffect(() => {
+        isPresentRef.current = isPresent
+        onExitCompleteRef.current = onExitComplete
+    })
 
     let isReusedContext = true
     let context = useMemo((): PresenceContextProps => {
@@ -70,10 +75,10 @@ export const PresenceChild = ({
                 return () => {
                     presenceChildren.delete(childId)
                     if (
-                        !latest.current.isPresent &&
+                        !isPresentRef.current &&
                         !presenceChildren.size
                     ) {
-                        latest.current.onExitComplete?.()
+                        onExitCompleteRef.current?.()
                     }
                 }
             },

--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { useId, useMemo } from "react"
+import { useId, useMemo, useRef } from "react"
 import {
     PresenceContext,
     type PresenceContextProps,
@@ -38,6 +38,16 @@ export const PresenceChild = ({
     const presenceChildren = useConstant(newChildrenMap)
     const id = useId()
 
+    /**
+     * Track the latest `isPresent` and `onExitComplete` so the cleanup
+     * returned from `register` can read up-to-date values. The cleanup
+     * fires whenever a motion child unmounts; if it unmounts during exit
+     * and was the last registered child, we need to fire `onExitComplete`
+     * here because the parent useEffect won't re-run.
+     */
+    const latest = useRef({ isPresent, onExitComplete })
+    latest.current = { isPresent, onExitComplete }
+
     let isReusedContext = true
     let context = useMemo((): PresenceContextProps => {
         isReusedContext = false
@@ -57,7 +67,15 @@ export const PresenceChild = ({
             },
             register: (childId: string) => {
                 presenceChildren.set(childId, false)
-                return () => presenceChildren.delete(childId)
+                return () => {
+                    presenceChildren.delete(childId)
+                    if (
+                        !latest.current.isPresent &&
+                        !presenceChildren.size
+                    ) {
+                        latest.current.onExitComplete?.()
+                    }
+                }
             },
         }
     }, [isPresent, presenceChildren, onExitComplete])

--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -39,13 +39,8 @@ export const PresenceChild = ({
     const presenceChildren = useConstant(newChildrenMap)
     const id = useId()
 
-    /**
-     * Track the latest committed `isPresent` and `onExitComplete` so the
-     * cleanup returned from `register` can read up-to-date values when a
-     * motion child unmounts mid-exit. The ref is written in a layout
-     * effect — not during render — so discarded concurrent renders never
-     * leave it pointing at uncommitted state.
-     */
+    // Written in a layout effect (not render) so discarded concurrent
+    // renders can't leave the refs pointing at uncommitted state.
     const isPresentRef = useRef(isPresent)
     const onExitCompleteRef = useRef(onExitComplete)
     useIsomorphicLayoutEffect(() => {
@@ -74,12 +69,9 @@ export const PresenceChild = ({
                 presenceChildren.set(childId, false)
                 return () => {
                     presenceChildren.delete(childId)
-                    if (
-                        !isPresentRef.current &&
-                        !presenceChildren.size
-                    ) {
+                    !isPresentRef.current &&
+                        !presenceChildren.size &&
                         onExitCompleteRef.current?.()
-                    }
                 }
             },
         }

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -1801,4 +1801,59 @@ describe("AnimatePresence with custom components", () => {
         // Child should have been removed after exit animation completes
         expect(container.childElementCount).toBe(0)
     })
+
+    test("Removes child when motion components inside unmount during exit (#3243)", async () => {
+        /**
+         * Reproduction for #3243: when an exit animation has been
+         * triggered for a child of AnimatePresence and the only motion
+         * component inside that child then unmounts on a subsequent
+         * render, the exit state should not get stuck. With no motion
+         * components left to drive the exit animation, PresenceChild
+         * should detect all children have unregistered and call
+         * onExitComplete.
+         */
+        let setChildOpen: ((open: boolean) => void) | null = null
+
+        const Child = () => {
+            const [isOpen, setIsOpen] = React.useState(true)
+            setChildOpen = setIsOpen
+            return isOpen ? (
+                <motion.div
+                    data-testid="motion"
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 10 }}
+                />
+            ) : (
+                <div data-testid="closed">closed</div>
+            )
+        }
+
+        const Component = ({ isVisible }: { isVisible: boolean }) => (
+            <AnimatePresence>
+                {isVisible && <Child key="child" />}
+            </AnimatePresence>
+        )
+
+        const { container, rerender } = render(<Component isVisible />)
+
+        // Step 1: trigger exit. Child still renders motion.div, so
+        // PresenceChild flips isPresent=false while a motion child is
+        // still registered.
+        rerender(<Component isVisible={false} />)
+
+        // Step 2: child internally re-renders without the motion
+        // component. Without the fix, PresenceChild never detects that
+        // all motion children have unregistered, so onExitComplete is
+        // never fired and the wrapper stays in the DOM forever.
+        await act(async () => {
+            setChildOpen!(false)
+        })
+
+        await act(async () => {
+            await nextFrame()
+            await nextFrame()
+        })
+
+        expect(container.childElementCount).toBe(0)
+    })
 })


### PR DESCRIPTION
## Summary

- When a motion child inside an `AnimatePresence` wrapper unmounts on a render after its exit was already triggered, `PresenceChild` would never call `onExitComplete`, leaving the wrapper stuck in the tree.
- The existing `useEffect` only handled the case where the children map was already empty when `isPresent` flipped — it never re-ran after a later motion-child unmount.
- The `register` cleanup now also checks the latest `isPresent` (via a ref to avoid the closure capture) and fires `onExitComplete` when the last registered child unmounts during exit.

## Bug

Issue #3243: when a child of `AnimatePresence` triggers exit and the only `motion` component inside it unmounts on the next render (e.g. because of internal state), the child stayed rendered indefinitely and showed its post-unmount UI.

## Test

Added a regression test that reproduces the reporter's scenario: render a child with an internal `useState` toggle that swaps `<motion.div>` for a non-motion element after exit is triggered. Without the fix the wrapper persists; with the fix the child is removed.

Fixes #3243

## Test plan

- [x] `yarn build`
- [x] `yarn test` (794 passed, 7 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)