### PR TITLE
Fix #3101: Normalise unitless 0 in clipPath WAAPI keyframes

### DIFF
--- a/dev/react/src/tests/animate-clip-path.tsx
+++ b/dev/react/src/tests/animate-clip-path.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react"
+import { motion } from "framer-motion"
+
+/**
+ * Test for #3101 — clipPath animation should interpolate cleanly between
+ * two `inset()` values that mix unitless `0` and `0px` lengths.
+ */
+export const App = () => {
+    const [collapse, setCollapse] = useState(false)
+
+    return (
+        <section
+            id="trigger"
+            onClick={() => setCollapse(!collapse)}
+            style={{ width: 500, height: 200 }}
+        >
+            <motion.div
+                id="box"
+                style={{
+                    width: 500,
+                    height: 200,
+                    background: "red",
+                }}
+                animate={{
+                    clipPath: collapse
+                        ? "inset(0 120px 0 120px)"
+                        : "inset(0 0px 0 0px)",
+                }}
+                transition={{ duration: 1, ease: "linear" }}
+            />
+        </section>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-clip-path.ts
+++ b/packages/framer-motion/cypress/integration/animate-clip-path.ts
@@ -1,0 +1,41 @@
+describe("animate clipPath (#3101)", () => {
+    it("interpolates inset() values smoothly through WAAPI", () => {
+        cy.visit("?test=animate-clip-path")
+            .wait(200)
+            .get("#trigger")
+            .trigger("click", { force: true })
+            // Mid-animation (linear, 1s duration), expect ~half-way
+            .wait(500)
+            .get("#box")
+            .should(($el) => {
+                const el = $el[0] as HTMLElement
+                const clipPath = getComputedStyle(el).clipPath
+                // Extract numeric values from inset() string
+                const matches = clipPath.match(/-?\d+(?:\.\d+)?/g)
+                expect(matches, `clipPath was: ${clipPath}`).to.not.be.null
+                const numbers = matches!.map(Number)
+                // inset() resolves to 4 values [top, right, bottom, left].
+                // For our animation top/bottom stay 0, left/right go 0 → 120.
+                // At ~50% progress, left and right should be roughly 60 (give a wide tolerance).
+                expect(numbers.length).to.be.at.least(2)
+                // Find the largest value — it should be a meaningful intermediate
+                // value (not 0 and not the final 120).
+                const max = Math.max(...numbers)
+                expect(max, `expected mid-animation value, got ${clipPath}`)
+                    .to.be.greaterThan(20)
+                    .and.lessThan(100)
+            })
+            // Wait for animation to complete
+            .wait(700)
+            .get("#box")
+            .should(($el) => {
+                const el = $el[0] as HTMLElement
+                const clipPath = getComputedStyle(el).clipPath
+                const numbers = (clipPath.match(/-?\d+(?:\.\d+)?/g) || []).map(
+                    Number
+                )
+                const max = Math.max(...numbers)
+                expect(max).to.be.closeTo(120, 1)
+            })
+    })
+})

--- a/packages/motion-dom/src/animation/waapi/start-waapi-animation.ts
+++ b/packages/motion-dom/src/animation/waapi/start-waapi-animation.ts
@@ -2,6 +2,7 @@ import { activeAnimations } from "../../stats/animation-count"
 import { statsBuffer } from "../../stats/buffer"
 import { ValueKeyframesDefinition, ValueTransition } from "../types"
 import { mapEasingToNativeEasing } from "./easing/map-easing"
+import { normaliseAcceleratedKeyframes } from "./utils/normalize-keyframes"
 
 export function startWaapiAnimation(
     element: Element,
@@ -18,7 +19,10 @@ export function startWaapiAnimation(
     pseudoElement: string | undefined = undefined
 ) {
     const keyframeOptions: PropertyIndexedKeyframes = {
-        [valueName]: keyframes as string[],
+        [valueName]: normaliseAcceleratedKeyframes(
+            valueName,
+            keyframes
+        ) as string[],
     }
     if (times) keyframeOptions.offset = times
 

--- a/packages/motion-dom/src/animation/waapi/utils/__tests__/normalize-keyframes.test.ts
+++ b/packages/motion-dom/src/animation/waapi/utils/__tests__/normalize-keyframes.test.ts
@@ -1,0 +1,84 @@
+import { normaliseAcceleratedKeyframes } from "../normalize-keyframes"
+
+describe("normaliseAcceleratedKeyframes", () => {
+    test("ignores unrelated properties", () => {
+        expect(
+            normaliseAcceleratedKeyframes("opacity", [0, 1])
+        ).toEqual([0, 1])
+        expect(
+            normaliseAcceleratedKeyframes("transform", [
+                "translateX(0)",
+                "translateX(100px)",
+            ])
+        ).toEqual(["translateX(0)", "translateX(100px)"])
+    })
+
+    test("converts unitless 0 to 0px in clipPath inset() values", () => {
+        expect(
+            normaliseAcceleratedKeyframes("clipPath", [
+                "inset(0 0px 0 0px)",
+                "inset(0 120px 0 120px)",
+            ])
+        ).toEqual([
+            "inset(0px 0px 0px 0px)",
+            "inset(0px 120px 0px 120px)",
+        ])
+    })
+
+    test("leaves already-normalised clipPath values untouched", () => {
+        expect(
+            normaliseAcceleratedKeyframes("clipPath", [
+                "inset(0px 0px 0px 0px)",
+                "inset(0px 120px 0px 120px)",
+            ])
+        ).toEqual([
+            "inset(0px 0px 0px 0px)",
+            "inset(0px 120px 0px 120px)",
+        ])
+    })
+
+    test("does not change percentage values", () => {
+        expect(
+            normaliseAcceleratedKeyframes("clipPath", [
+                "inset(0% 0% 0% 0%)",
+                "inset(0% 50% 0% 50%)",
+            ])
+        ).toEqual(["inset(0% 0% 0% 0%)", "inset(0% 50% 0% 50%)"])
+    })
+
+    test("normalises bare zero shorthand", () => {
+        expect(
+            normaliseAcceleratedKeyframes("clipPath", [
+                "inset(0)",
+                "inset(20px)",
+            ])
+        ).toEqual(["inset(0px)", "inset(20px)"])
+    })
+
+    test("normalises polygon points", () => {
+        expect(
+            normaliseAcceleratedKeyframes("clipPath", [
+                "polygon(0 0, 100% 0, 100% 100%, 0 100%)",
+                "polygon(20px 20px, 100% 20px, 100% 80%, 20px 80%)",
+            ])
+        ).toEqual([
+            "polygon(0px 0px, 100% 0px, 100% 100%, 0px 100%)",
+            "polygon(20px 20px, 100% 20px, 100% 80%, 20px 80%)",
+        ])
+    })
+
+    test("handles a single keyframe value", () => {
+        expect(
+            normaliseAcceleratedKeyframes(
+                "clipPath",
+                "inset(0 0px 0 0px)"
+            )
+        ).toBe("inset(0px 0px 0px 0px)")
+    })
+
+    test("does not touch numeric or null keyframes", () => {
+        expect(
+            normaliseAcceleratedKeyframes("clipPath", [null, "inset(0 0)"])
+        ).toEqual([null, "inset(0px 0px)"])
+    })
+})

--- a/packages/motion-dom/src/animation/waapi/utils/normalize-keyframes.ts
+++ b/packages/motion-dom/src/animation/waapi/utils/normalize-keyframes.ts
@@ -1,0 +1,36 @@
+import { AnyResolvedKeyframe, ValueKeyframesDefinition } from "../../types"
+
+/**
+ * Match a unitless `0` length value followed by whitespace, comma, or
+ * close paren — i.e. a CSS length-position where `0` is equivalent to `0px`
+ * but uses no explicit unit.
+ *
+ * Used to normalise shape functions (e.g. `inset(0 0px 0 0px)`) so that
+ * every length token carries the same unit. Chromium 134 intermittently
+ * fails to interpolate `clip-path: inset(...)` keyframes that mix unitless
+ * `0` and `0px` lengths — see #3101.
+ */
+const unitlessZeroLength = /(^|[\s,(])0(?=[\s,)])/g
+
+function addPxToZeros(value: string): string {
+    return value.replace(unitlessZeroLength, "$10px")
+}
+
+const propsToNormalise = new Set(["clipPath"])
+
+export function normaliseAcceleratedKeyframes(
+    name: string,
+    keyframes: ValueKeyframesDefinition
+): ValueKeyframesDefinition {
+    if (!propsToNormalise.has(name)) return keyframes
+
+    if (Array.isArray(keyframes)) {
+        return (keyframes as AnyResolvedKeyframe[]).map((keyframe) =>
+            typeof keyframe === "string" ? addPxToZeros(keyframe) : keyframe
+        ) as ValueKeyframesDefinition
+    }
+
+    return typeof keyframes === "string"
+        ? (addPxToZeros(keyframes) as ValueKeyframesDefinition)
+        : keyframes
+}


### PR DESCRIPTION
## Summary

- Chromium 134 intermittently fails to interpolate `clip-path: inset(...)` keyframes that mix unitless `0` and `0px` lengths (the user's reproduction toggles between `inset(0 0px 0 0px)` and `inset(0 120px 0 120px)`), producing janky / glitching animations.
- Before handing accelerated keyframes to `element.animate()`, replace any bare `0` length token (`0` followed by whitespace, comma, or close-paren) with `0px` so every length in the keyframe carries an explicit unit.
- Scoped to `clipPath` for now since that is what's reported, but the helper takes a property-name allow list so additional shape-style properties can be added if more reports surface.

## Cause

`getComputedStyle` and `getAnimatableNone` both preserve whichever unit notation the user supplies, so the keyframe pair Motion hands to WAAPI can keep the user's mixed `0`/`0px` form. In Chromium 134 that mixed form interpolates incorrectly. Normalising to `0px` produces a CSS-equivalent string that interpolates cleanly.

## Notes for review

- The bug does not reproduce in the Electron 80 used by Cypress, nor in the Chromium 138 bundled with Playwright (the Chromium fix appears to have shipped after 134). The Cypress test added here therefore serves as integration coverage rather than a hard regression gate; the unit tests around `normaliseAcceleratedKeyframes` are the real regression guard.
- All 793 unit tests still pass; new and existing Cypress `waapi`/`animate-style`/`animate-filter-blur` tests pass on both React 18 and React 19.

Fixes #3101

## Test plan

- [x] `yarn test` (793 passed, 7 skipped)
- [x] Cypress `animate-clip-path.ts` on React 18 and React 19
- [x] Cypress `waapi.ts`, `animate-filter-blur.ts`, `animate-style.ts`, `waapi-interrupt-transform.ts` regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)