### PR TITLE
Fix LazyMotion not working with motion/react-m subpath (#3091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Undocumented APIs should be considered internal and may change without warning.
 ### Fixed
 
 -   Variants: Re-run keyframe animations when switching between variant labels even when they share identical keyframe arrays.
+-   `LazyMotion`: Share React contexts between the `framer-motion` and `framer-motion/m` (and therefore `motion/react` and `motion/react-m`) CJS bundles so that `<m.div>` from the `/m` subpath picks up features loaded by `<LazyMotion>` from the main entry point.
 
 ## [12.39.0] 2026-05-05
 

--- a/dev/react/package.json
+++ b/dev/react/package.json
@@ -14,6 +14,7 @@
         "@base-ui-components/react": "^1.0.0-rc.0",
         "@tanstack/react-virtual": "^3.13.22",
         "framer-motion": "^12.38.0",
+        "motion": "^12.38.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },

--- a/dev/react/src/tests/lazy-motion-react-m-subpath.tsx
+++ b/dev/react/src/tests/lazy-motion-react-m-subpath.tsx
@@ -1,0 +1,46 @@
+import { LazyMotion, domAnimation } from "motion/react"
+import * as m from "motion/react-m"
+import { useEffect, useRef } from "react"
+
+/**
+ * Test for GitHub issue #3091
+ *
+ * LazyMotion (from `motion/react`) wrapping `m.div` from the `motion/react-m`
+ * subpath. The LazyMotion-supplied renderer and feature definitions must reach
+ * the m component even though the m components come from a separately-bundled
+ * subpath, otherwise the m component renders nothing animated.
+ */
+export const App = () => {
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const id = setTimeout(() => {
+            if (ref.current && !ref.current.dataset.animationComplete) {
+                ref.current.dataset.animationFailed = "true"
+            }
+        }, 1000)
+        return () => clearTimeout(id)
+    }, [])
+
+    return (
+        <LazyMotion features={domAnimation}>
+            <m.div
+                id="box"
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.1 }}
+                onAnimationComplete={() => {
+                    if (ref.current) {
+                        ref.current.dataset.animationComplete = "true"
+                    }
+                }}
+                style={{
+                    width: 100,
+                    height: 100,
+                    background: "red",
+                }}
+            />
+        </LazyMotion>
+    )
+}

--- a/packages/framer-motion/cypress/integration/lazy-motion-react-m-subpath.ts
+++ b/packages/framer-motion/cypress/integration/lazy-motion-react-m-subpath.ts
@@ -1,0 +1,12 @@
+describe("LazyMotion with m components from /m subpath (issue #3091)", () => {
+    it("animates m.div from framer-motion/m inside LazyMotion from framer-motion", () => {
+        cy.visit("?test=lazy-motion-react-m-subpath")
+            .wait(500)
+            .get("#box")
+            .should(([$element]: any) => {
+                expect($element.dataset.animationFailed).to.not.equal("true")
+                expect($element.dataset.animationComplete).to.equal("true")
+                expect(getComputedStyle($element).opacity).to.equal("1")
+            })
+    })
+})

--- a/packages/framer-motion/rollup.config.mjs
+++ b/packages/framer-motion/rollup.config.mjs
@@ -113,7 +113,15 @@ const umdDomProd = createUmd("lib/dom.js", `dist/dom.js`)
 const umdDomMiniProd = createUmd("lib/dom-mini.js", `dist/dom-mini.js`)
 
 const cjs = Object.assign({}, config, {
-    input: ["lib/index.js", "lib/client.js"],
+    /**
+     * `lib/m.js` is bundled here alongside `lib/index.js` so that the React
+     * contexts (LazyContext, MotionContext, etc.) are emitted in a shared
+     * chunk and not duplicated across the two CJS entry points. Without this,
+     * `<LazyMotion>` from the main entry can't communicate with `<m.div>`
+     * from the `/m` subpath because each CJS bundle would have its own
+     * `createContext()` instance. See issue #3091.
+     */
+    input: ["lib/index.js", "lib/client.js", "lib/m.js"],
     output: {
         entryFileNames: `[name].js`,
         dir: "dist/cjs",
@@ -139,7 +147,6 @@ const cjsDebug = Object.assign({}, cjs, { input : "lib/debug.js" })
 const cjsDom = Object.assign({}, cjs, { input : "lib/dom.js" })
 const cjsMini = Object.assign({}, cjs, { input : "lib/mini.js" })
 const cjsDomMini = Object.assign({}, cjs, { input : "lib/dom-mini.js" })
-const cjsM = Object.assign({}, cjs, { input : "lib/m.js" })
 
 export const es = Object.assign({}, config, {
     input: ["lib/index.js", "lib/mini.js", "lib/debug.js", "lib/dom.js", "lib/dom-mini.js", "lib/client.js", "lib/m.js","lib/projection.js"],
@@ -195,7 +202,6 @@ export default [
     cjsMini,
     cjsDom,
     cjsDomMini,
-    cjsM,
     es,
     indexTypes,
     clientTypes,

--- a/packages/framer-motion/scripts/check-bundle.js
+++ b/packages/framer-motion/scripts/check-bundle.js
@@ -42,3 +42,18 @@ for (const [name, entry] of Object.entries(pkg.exports)) {
         )
     }
 }
+
+/**
+ * Verify that the CJS m bundle does not declare its own React contexts. If it
+ * does, `<LazyMotion>` from the main entry can't communicate with `<m.div>`
+ * because each CJS bundle would have a separate `createContext()` instance
+ * (#3091). The shared CJS chunk emitted from the rollup `cjs` build must
+ * supply `LazyContext`, `MotionContext` etc. to both `index.js` and `m.js`.
+ */
+const cjsM = readFileSync(path.join(dist, "cjs", "m.js"), "utf8")
+const ownLazyContext = cjsM.match(/createContext\(\{ strict: false \}\)/g)
+if (ownLazyContext) {
+    throw new Error(
+        `CJS m bundle (dist/cjs/m.js) defines its own LazyContext (${ownLazyContext.length} time(s)) instead of importing it from the shared chunk — this breaks LazyMotion + m component interop across CJS bundles (#3091)`
+    )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12932,6 +12932,7 @@ __metadata:
     "@vitejs/plugin-react-swc": ^3.5.0
     eslint-plugin-react-refresh: ^0.4.6
     framer-motion: ^12.38.0
+    motion: ^12.38.0
     react: ^18.3.1
     react-dom: ^18.3.1
     vite: ^6.4.2


### PR DESCRIPTION
## Summary

Fixes #3091 — `<LazyMotion>` from `motion/react` couldn't load features for `<m.div>` imported from `motion/react-m`. When users wrapped m components from the `/m` subpath in a `<LazyMotion>` provider, the m components silently rendered without animations, gestures, or layout features.

## Cause

The CJS bundles for the main `framer-motion` entry and the `framer-motion/m` subpath were emitted in separate rollup invocations, with a comment that intentionally avoided sharing chunks. Each CJS bundle therefore made its own `createContext()` calls for `LazyContext`, `MotionContext`, `MotionConfigContext`, etc.

`createContext()` returns a unique object each time it is called, so the two bundles ended up with two distinct React Context instances. The `<LazyMotion>` from `motion/react` published the renderer and feature definitions on its bundle's `LazyContext`; the `<m.div>` from `motion/react-m` read from a different `LazyContext` whose value was the default `{ strict: false }` (no renderer). The m component never built a `VisualElement`, so nothing animated.

ESM consumers were unaffected because the ESM build uses `preserveModules: true`, so the shared `dist/es/context/LazyContext.mjs` resolves to a single module.

## Fix

Bundle `lib/m.js` together with `lib/index.js` in the same CJS rollup invocation. Rollup hoists shared modules (the contexts, `createMotionComponent`, `useVisualElement`, etc.) into a common chunk that both entry points require, so `framer-motion/dist/cjs/index.js` and `framer-motion/dist/cjs/m.js` now reference the same context instances. ESM and the existing per-entry CJS bundles for `dom`, `dom-mini`, `mini`, and `debug` are unchanged.

## Regression coverage

- `packages/framer-motion/scripts/check-bundle.js` now fails the build if `dist/cjs/m.js` re-introduces its own `createContext({ strict: false })` call.
- `dev/react/src/tests/lazy-motion-react-m-subpath.tsx` + `packages/framer-motion/cypress/integration/lazy-motion-react-m-subpath.ts` exercise `<LazyMotion features={domAnimation}>` wrapping `<m.div>` from `motion/react-m`.

## Test plan

- [x] `yarn build` succeeds (check-bundle gate passes).
- [x] `yarn test` — 793 unit tests pass.
- [x] Cypress `lazy-motion-react-m-subpath` passes on React 18.
- [x] Cypress `lazy-motion-react-m-subpath` passes on React 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)