### PR TITLE
Fix unitless numeric strings in transform/style values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Undocumented APIs should be considered internal and may change without warning.
 ### Fixed
 
 -   Variants: Re-run keyframe animations when switching between variant labels even when they share identical keyframe arrays.
+-   Apply default unit to unitless numeric strings (e.g. `"42"`) in transform/style values, so values like `animate={{ x: "42" }}` produce valid CSS.
 
 ## [12.39.0] 2026-05-05
 

--- a/packages/framer-motion/src/render/html/utils/__tests__/build-transform.test.ts
+++ b/packages/framer-motion/src/render/html/utils/__tests__/build-transform.test.ts
@@ -108,4 +108,13 @@ describe("buildTransform", () => {
         expect(buildTransform({ scaleX: "0" }, {})).toBe("scaleX(0)")
         expect(buildTransform({ scaleY: "0" }, {})).toBe("scaleY(0)")
     })
+
+    it("Adds default unit to unitless numeric strings", () => {
+        // Reproduces #3086: strings like "15" must be treated like numbers
+        // and have the default unit applied, otherwise the browser ignores the
+        // resulting transform (e.g. translateX(15) is invalid CSS).
+        expect(buildTransform({ x: "15" }, {})).toBe("translateX(15px)")
+        expect(buildTransform({ y: "42" }, {})).toBe("translateY(42px)")
+        expect(buildTransform({ rotate: "90" }, {})).toBe("rotate(90deg)")
+    })
 })

--- a/packages/motion-dom/src/effects/attr/index.ts
+++ b/packages/motion-dom/src/effects/attr/index.ts
@@ -44,7 +44,7 @@ export const addAttrValue = (
               }
           }
 
-    return state.set(key, value, render)
+    return state.set(key, value, render, undefined, false)
 }
 
 export const attrEffect = /*@__PURE__*/ createSelectorEffect(

--- a/packages/motion-dom/src/value/types/__tests__/value-types.test.ts
+++ b/packages/motion-dom/src/value/types/__tests__/value-types.test.ts
@@ -48,4 +48,10 @@ describe("getValueAsType", () => {
         expect(getValueAsType("100%", px)).toBe("100%")
         expect(getValueAsType(100)).toBe(100)
     })
+
+    it("Applies the default unit to unitless numeric strings (issue #3086)", () => {
+        expect(getValueAsType("15", px)).toBe("15px")
+        expect(getValueAsType("0", px)).toBe("0px")
+        expect(getValueAsType("-1.5", px)).toBe("-1.5px")
+    })
 })

--- a/packages/motion-dom/src/value/types/utils/get-as-type.ts
+++ b/packages/motion-dom/src/value/types/utils/get-as-type.ts
@@ -2,9 +2,16 @@ import { ValueType } from "../types"
 
 /**
  * Provided a value and a ValueType, returns the value as that value type.
+ *
+ * Numeric strings without a unit (e.g. `"15"`) are treated like numbers and
+ * have the default unit applied. Strings that already include a unit (e.g.
+ * `"15px"` or `"100%"`) pass through unchanged.
  */
 export const getValueAsType = (value: any, type?: ValueType) => {
-    return type && typeof value === "number"
-        ? (type as any).transform(value)
-        : value
+    if (!type) return value
+    if (typeof value === "number") return (type as any).transform(value)
+    if (typeof value === "string" && value !== "" && !isNaN(value as any)) {
+        return (type as any).transform(value)
+    }
+    return value
 }


### PR DESCRIPTION
## Summary

Fixes #3086.

`<motion.rect animate={{ x: "15" }} />` (or any string-encoded number passed to a CSS transform/style value) had no visible effect because `getValueAsType` only applied default units to numeric values, leaving `"15"` untouched. The result was an invalid CSS string like `transform: translateX(15)` which the browser silently ignores.

## Cause

`getValueAsType(value, type)` returned the value unchanged whenever `typeof value !== "number"`, so string inputs like `"15"` skipped unit application. Strings already including a unit (e.g. `"15px"`, `"100%"`) were correctly preserved.

## Fix

- Treat unitless numeric strings the same as numbers in `getValueAsType`. `"15"` now becomes `"15px"` (or the property's appropriate default unit).
- `attrEffect` now opts out of default value typing (`useDefaultValueType: false`), matching `propEffect`. SVG attributes such as `width="100"` accept naked numeric strings natively and shouldn't have CSS units appended.

## Test plan

- [x] New unit test in `build-transform.test.ts` reproduces the bug (fails before the fix, passes after).
- [x] New unit test in `value-types.test.ts` covers `getValueAsType` for unitless numeric strings.
- [x] Existing `attrEffect` tests continue to pass — SVG `width="100"` round-trips as `"100"`, not `"100px"`.
- [x] Full `yarn test` passes (motion-utils, motion-dom, framer-motion).
- [x] `yarn build` succeeds.