### PR TITLE
Add AnimateSuspense component for animated suspense fallback transitions

### DIFF
--- a/dev/react/src/tests/animate-suspense.tsx
+++ b/dev/react/src/tests/animate-suspense.tsx
@@ -1,0 +1,75 @@
+import { lazy, useEffect } from "react"
+import { motion, AnimateSuspense } from "framer-motion"
+
+/**
+ * Test for AnimateSuspense component (issue #3173).
+ *
+ * Two modes via ?mode=:
+ *   "suspend" (default): React.lazy children that suspend for 500ms, then resolve.
+ *   "sync":              Children that never suspend — fallback must never render.
+ */
+
+const params = new URLSearchParams(window.location.search)
+const mode = params.get("mode") || "suspend"
+
+const LazyContent = lazy(
+    () =>
+        new Promise<{ default: React.ComponentType }>((resolve) => {
+            setTimeout(() => {
+                resolve({
+                    default: () => (
+                        <motion.div
+                            id="content"
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            transition={{ duration: 0.3 }}
+                        >
+                            Loaded Content
+                        </motion.div>
+                    ),
+                })
+            }, 500)
+        })
+)
+
+const SyncContent = () => (
+    <motion.div
+        id="content"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3 }}
+    >
+        Sync Content
+    </motion.div>
+)
+
+function Fallback() {
+    useEffect(() => {
+        const w = window as unknown as { __fallbackMountCount?: number }
+        w.__fallbackMountCount = (w.__fallbackMountCount || 0) + 1
+    }, [])
+
+    return (
+        <motion.div
+            id="fallback"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5 }}
+        >
+            Loading...
+        </motion.div>
+    )
+}
+
+;(window as unknown as { __fallbackMountCount: number }).__fallbackMountCount = 0
+
+export function App() {
+    const Content = mode === "sync" ? SyncContent : LazyContent
+
+    return (
+        <AnimateSuspense fallback={<Fallback />}>
+            <Content />
+        </AnimateSuspense>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-suspense.ts
+++ b/packages/framer-motion/cypress/integration/animate-suspense.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for AnimateSuspense (issue #3173).
+ *
+ * Covers:
+ *   1. Suspended children: fallback appears, exits when content resolves.
+ *   2. Non-suspending children: fallback must never mount (no initial flash).
+ */
+describe("AnimateSuspense", () => {
+    it("animates fallback out when suspended children resolve", () => {
+        cy.visit("?test=animate-suspense&mode=suspend")
+            .wait(100)
+            // Fallback visible while suspended.
+            .get("#fallback")
+            .should("exist")
+
+            // Content appears after lazy import resolves (~500ms).
+            .get("#content", { timeout: 5000 })
+            .should("exist")
+            .should("contain", "Loaded Content")
+
+            // Fallback exits after its exit animation completes.
+            .get("#fallback", { timeout: 5000 })
+            .should("not.exist")
+    })
+
+    it("does not render fallback when children do not suspend", () => {
+        cy.visit("?test=animate-suspense&mode=sync")
+            .wait(200)
+            .get("#content")
+            .should("exist")
+            .should("contain", "Sync Content")
+            .window()
+            .then((win) => {
+                const count = (
+                    win as unknown as { __fallbackMountCount?: number }
+                ).__fallbackMountCount
+                expect(count).to.equal(0)
+            })
+    })
+})

--- a/packages/framer-motion/src/components/AnimateSuspense/__tests__/AnimateSuspense.test.tsx
+++ b/packages/framer-motion/src/components/AnimateSuspense/__tests__/AnimateSuspense.test.tsx
@@ -1,0 +1,76 @@
+import { waitFor } from "@testing-library/dom"
+import * as React from "react"
+import { lazy, Suspense } from "react"
+import { AnimateSuspense, motion } from "../../.."
+import { render } from "../../../jest.setup"
+
+/**
+ * @jest-environment jsdom
+ */
+describe("AnimateSuspense", () => {
+    test("renders children directly when they do not suspend", () => {
+        const { container, queryByText } = render(
+            <AnimateSuspense
+                fallback={<div data-testid="fallback">Loading</div>}
+            >
+                <div data-testid="content">Content</div>
+            </AnimateSuspense>
+        )
+
+        expect(queryByText("Content")).not.toBeNull()
+        // Fallback must not be in the DOM when children resolve synchronously.
+        expect(container.querySelector('[data-testid="fallback"]')).toBeNull()
+    })
+
+    test("renders fallback while children are suspended", async () => {
+        let resolveLazy: () => void = () => {}
+        const LazyChild = lazy(
+            () =>
+                new Promise<{ default: React.ComponentType }>((resolve) => {
+                    resolveLazy = () =>
+                        resolve({
+                            default: () => (
+                                <div data-testid="content">Loaded</div>
+                            ),
+                        })
+                })
+        )
+
+        const { queryByText, queryByTestId } = render(
+            <AnimateSuspense
+                fallback={
+                    <motion.div data-testid="fallback" exit={{ opacity: 0 }}>
+                        Loading
+                    </motion.div>
+                }
+            >
+                <LazyChild />
+            </AnimateSuspense>
+        )
+
+        // Fallback should be visible while suspended.
+        await waitFor(() => {
+            expect(queryByTestId("fallback")).not.toBeNull()
+        })
+
+        // Resolve the lazy import.
+        resolveLazy()
+
+        await waitFor(() => {
+            expect(queryByText("Loaded")).not.toBeNull()
+        })
+    })
+
+    test("accepts the same props shape as React.Suspense", () => {
+        // Compile-time check: AnimateSuspense's required props match Suspense's.
+        const fallback = <div>Loading</div>
+        const children = <div>Hello</div>
+
+        const _native = <Suspense fallback={fallback}>{children}</Suspense>
+        const _animated = (
+            <AnimateSuspense fallback={fallback}>{children}</AnimateSuspense>
+        )
+        expect(_native).toBeTruthy()
+        expect(_animated).toBeTruthy()
+    })
+})

--- a/packages/framer-motion/src/components/AnimateSuspense/index.tsx
+++ b/packages/framer-motion/src/components/AnimateSuspense/index.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import * as React from "react"
+import { Suspense, useRef, useState } from "react"
+import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
+import { AnimatePresence } from "../AnimatePresence"
+import type { AnimateSuspenseProps } from "./types"
+
+type SetSuspendedRef = React.MutableRefObject<(v: boolean) => void>
+
+/**
+ * Rendered as React's Suspense fallback. Its mount/unmount tells us when
+ * the boundary enters/leaves the suspended state.
+ */
+function SuspenseTracker({ setRef }: { setRef: SetSuspendedRef }) {
+    useIsomorphicLayoutEffect(() => {
+        setRef.current(true)
+        return () => setRef.current(false)
+    }, [])
+    return null
+}
+
+/**
+ * Wraps the actual children. Its mount confirms children rendered without
+ * suspending, allowing us to flip `isSuspended` back to `false` regardless
+ * of whether the tracker above ever fired.
+ */
+function ResolveTracker({
+    children,
+    setRef,
+}: {
+    children: React.ReactNode
+    setRef: SetSuspendedRef
+}) {
+    useIsomorphicLayoutEffect(() => {
+        setRef.current(false)
+    }, [])
+    return <>{children}</>
+}
+
+/**
+ * `AnimateSuspense` enables animated transitions between a loading fallback
+ * and streamed or lazy-loaded content. It mirrors React's `Suspense` API but
+ * the `fallback` can be a `motion` component whose `exit` animation plays
+ * when children resolve.
+ *
+ * ```jsx
+ * import { motion, AnimateSuspense } from "framer-motion"
+ *
+ * <AnimateSuspense
+ *   fallback={
+ *     <motion.div
+ *       initial={{ opacity: 0 }}
+ *       animate={{ opacity: 1 }}
+ *       exit={{ opacity: 0 }}
+ *     >
+ *       Loading...
+ *     </motion.div>
+ *   }
+ * >
+ *   <LazyContent />
+ * </AnimateSuspense>
+ * ```
+ *
+ * The fallback only renders when children actually suspend — non-suspending
+ * children mount directly without a fallback flash.
+ *
+ * @public
+ */
+export function AnimateSuspense({
+    children,
+    fallback,
+    custom,
+    initial,
+    mode = "sync",
+    onExitComplete,
+}: AnimateSuspenseProps) {
+    const [isSuspended, setIsSuspended] = useState(false)
+
+    /**
+     * Stable ref-based callback so the tracker effects only depend on `[]`
+     * and never re-fire if `setIsSuspended` is ever wrapped by an HOC.
+     */
+    const setRef = useRef(setIsSuspended)
+    setRef.current = setIsSuspended
+
+    return (
+        <>
+            <Suspense fallback={<SuspenseTracker setRef={setRef} />}>
+                <ResolveTracker setRef={setRef}>{children}</ResolveTracker>
+            </Suspense>
+            <AnimatePresence
+                custom={custom}
+                initial={initial}
+                mode={mode}
+                onExitComplete={onExitComplete}
+            >
+                {isSuspended ? fallback : null}
+            </AnimatePresence>
+        </>
+    )
+}

--- a/packages/framer-motion/src/components/AnimateSuspense/types.ts
+++ b/packages/framer-motion/src/components/AnimateSuspense/types.ts
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react"
+
+/**
+ * @public
+ */
+export interface AnimateSuspenseProps {
+    /**
+     * Content that may suspend, e.g. a `React.lazy()` component or a child
+     * that reads data from a suspending source.
+     */
+    children: ReactNode
+
+    /**
+     * Element displayed while `children` is suspended. To animate the
+     * fallback out when children resolve, use a `motion` component with an
+     * `exit` prop.
+     *
+     * ```jsx
+     * <AnimateSuspense
+     *   fallback={
+     *     <motion.div
+     *       initial={{ opacity: 0 }}
+     *       animate={{ opacity: 1 }}
+     *       exit={{ opacity: 0 }}
+     *     >
+     *       Loading...
+     *     </motion.div>
+     *   }
+     * >
+     *   <LazyContent />
+     * </AnimateSuspense>
+     * ```
+     */
+    fallback: ReactNode
+
+    /**
+     * By passing `initial={false}`, the fallback will not animate in when it
+     * first appears.
+     *
+     * @public
+     */
+    initial?: boolean
+
+    /**
+     * Determines how the fallback enters and exits relative to the children.
+     *
+     * - `"sync"`: Default. The fallback animates out at the same time as
+     *      `children` are revealed.
+     * - `"wait"`: The fallback finishes its exit animation before children
+     *      are revealed.
+     * - `"popLayout"`: The fallback is "popped" from the page layout while
+     *      exiting, allowing siblings to immediately occupy its space.
+     *
+     * @public
+     */
+    mode?: "sync" | "popLayout" | "wait"
+
+    /**
+     * Fires once the fallback has completed its exit animation.
+     *
+     * @public
+     */
+    onExitComplete?: () => void
+
+    /**
+     * Forwarded to `AnimatePresence`. Use this to drive dynamic exit variants
+     * on the fallback.
+     *
+     * @public
+     */
+    custom?: unknown
+}

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -3,6 +3,7 @@
  */
 export type * from "./animation/types"
 export { AnimatePresence } from "./components/AnimatePresence"
+export { AnimateSuspense } from "./components/AnimateSuspense"
 export { PopChild } from "./components/AnimatePresence/PopChild"
 export { PresenceChild } from "./components/AnimatePresence/PresenceChild"
 export { LayoutGroup } from "./components/LayoutGroup"
@@ -124,6 +125,7 @@ export { SwitchLayoutGroupContext } from "./context/SwitchLayoutGroupContext"
  * Types
  */
 export type { AnimatePresenceProps } from "./components/AnimatePresence/types"
+export type { AnimateSuspenseProps } from "./components/AnimateSuspense/types"
 export type { LazyProps } from "./components/LazyMotion/types"
 export type { MotionConfigProps } from "./components/MotionConfig"
 export type {


### PR DESCRIPTION
## Summary

Adds a new `<AnimateSuspense>` component that mirrors React's `<Suspense>` API but allows the `fallback` to animate out (via Motion's `exit` prop) once suspended children resolve. The primary use case is React.lazy / streaming content where users want to cross-fade or otherwise transition between a loading state and the resolved content.

```jsx
import { motion, AnimateSuspense } from "framer-motion"

<AnimateSuspense
  fallback={
    <motion.div
      initial={{ opacity: 0 }}
      animate={{ opacity: 1 }}
      exit={{ opacity: 0 }}
    >
      Loading...
    </motion.div>
  }
>
  <LazyContent />
</AnimateSuspense>
```

## Design

Sentinel-based: an empty `SuspenseTracker` is passed as React's `Suspense` fallback, and a `ResolveTracker` wraps the children. Their layout-effect mount/unmount toggles `isSuspended` state, which an internal `AnimatePresence` consumes to render and animate the user-supplied fallback.

`isSuspended` initialises to `false`. The fallback only renders when React actually suspends and mounts the `SuspenseTracker` — non-suspending children render directly without a fallback flash.

## Differences from the previous attempt (#3610)

That PR was closed unmerged after greptile flagged several issues. This iteration addresses them:

- **No initial-flash regression** — `isSuspended` starts as `false`, not `true`, so already-resolved children never briefly render the fallback. Covered by the new `mode=sync` Cypress and Jest tests.
- **Ref-based tracker callback** — the tracker effects depend on `[]` and read `setIsSuspended` through a ref, so they cannot fire spuriously if the setter is ever wrapped.
- **`custom` prop forwarded** — `AnimateSuspenseProps` now exposes `custom`, matching `AnimatePresence`.
- **Default `mode` is `"sync"`** — matches `AnimatePresence`'s default rather than overriding to `"wait"`.

## Test plan

- Jest: 3 new tests for `AnimateSuspense` (rendering with non-suspending and suspending children, prop-shape compatibility with `Suspense`). Full 803-test suite passes.
- Cypress (React 18 + React 19): two specs — one verifying the fallback enters, content resolves, and the fallback exits; one verifying the fallback never mounts when children don't suspend.
- Regression-checked by temporarily reverting `useState(false)` → `useState(true)`: the "does not render fallback when children do not suspend" spec fails, confirming the test catches the prior bug.

Fixes #3173

🤖 Generated with [Claude Code](https://claude.com/claude-code)