### PR TITLE
[audit] motion-utils/easing: NO_SIDE_EFFECTS annotations

### DIFF
--- a/packages/motion-utils/src/easing/cubic-bezier.ts
+++ b/packages/motion-utils/src/easing/cubic-bezier.ts
@@ -53,6 +53,7 @@ function binarySubdivide(
     return currentT
 }
 
+/*#__NO_SIDE_EFFECTS__*/
 export function cubicBezier(
     mX1: number,
     mY1: number,

--- a/packages/motion-utils/src/easing/modifiers/mirror.ts
+++ b/packages/motion-utils/src/easing/modifiers/mirror.ts
@@ -3,5 +3,6 @@
 import { EasingModifier } from "../types"
 
 // the second half of the animation. Turns easeIn into easeInOut.
+/*#__NO_SIDE_EFFECTS__*/
 export const mirrorEasing: EasingModifier = (easing) => (p) =>
     p <= 0.5 ? easing(2 * p) / 2 : (2 - easing(2 * (1 - p))) / 2

--- a/packages/motion-utils/src/easing/modifiers/reverse.ts
+++ b/packages/motion-utils/src/easing/modifiers/reverse.ts
@@ -3,5 +3,6 @@
 import { EasingModifier } from "../types"
 
 // Turns easeIn into easeOut.
+/*#__NO_SIDE_EFFECTS__*/
 export const reverseEasing: EasingModifier = (easing) => (p) =>
     1 - easing(1 - p)

--- a/packages/motion-utils/src/easing/steps.ts
+++ b/packages/motion-utils/src/easing/steps.ts
@@ -10,6 +10,7 @@ import type { EasingFunction } from "./types"
 */
 export type Direction = "start" | "end"
 
+/*#__NO_SIDE_EFFECTS__*/
 export function steps(
     numSteps: number,
     direction: Direction = "end"

--- a/packages/motion-utils/src/easing/utils/get-easing-for-segment.ts
+++ b/packages/motion-utils/src/easing/utils/get-easing-for-segment.ts
@@ -2,6 +2,7 @@ import { wrap } from "../../wrap"
 import { Easing } from "../types"
 import { isEasingArray } from "./is-easing-array"
 
+/*#__NO_SIDE_EFFECTS__*/
 export function getEasingForSegment(
     easing: Easing | Easing[],
     i: number

--- a/packages/motion-utils/src/easing/utils/is-bezier-definition.ts
+++ b/packages/motion-utils/src/easing/utils/is-bezier-definition.ts
@@ -1,5 +1,6 @@
 import { BezierDefinition, Easing } from "../types"
 
+/*#__NO_SIDE_EFFECTS__*/
 export const isBezierDefinition = (
     easing: Easing | Easing[]
 ): easing is BezierDefinition =>

--- a/packages/motion-utils/src/easing/utils/is-easing-array.ts
+++ b/packages/motion-utils/src/easing/utils/is-easing-array.ts
@@ -1,5 +1,6 @@
 import { Easing } from "../types"
 
+/*#__NO_SIDE_EFFECTS__*/
 export const isEasingArray = (ease: any): ease is Easing[] => {
     return Array.isArray(ease) && typeof ease[0] !== "number"
 }


### PR DESCRIPTION
## Summary

Adds `/*#__NO_SIDE_EFFECTS__*/` annotations to pure helper exports in `motion-utils/src/easing/`, matching the convention already established in motion-utils for `memo`, `noop`, `progress`, `secondsToMilliseconds`, `velocityPerSecond`, etc.

## What the directory does

Easing primitives shared across `motion-dom` and `framer-motion`:
- factories: `cubicBezier`, `steps`
- modifiers: `mirrorEasing`, `reverseEasing`
- type guards / helpers: `isBezierDefinition`, `isEasingArray`, `getEasingForSegment`
- pre-built curves: `ease*`, `back*`, `circ*`, `anticipate`

## Findings & changes

`/*#__NO_SIDE_EFFECTS__*/` added to 7 pure helpers:

| File | Helper |
|---|---|
| `easing/cubic-bezier.ts` | `cubicBezier` |
| `easing/steps.ts` | `steps` |
| `easing/modifiers/mirror.ts` | `mirrorEasing` |
| `easing/modifiers/reverse.ts` | `reverseEasing` |
| `easing/utils/is-bezier-definition.ts` | `isBezierDefinition` |
| `easing/utils/is-easing-array.ts` | `isEasingArray` |
| `easing/utils/get-easing-for-segment.ts` | `getEasingForSegment` |

The pre-built curves (`backOut`, `easeIn`, …) already carry `/*@__PURE__*/` at their call sites in `back.ts` and `ease.ts`. With these annotations, the equivalent call sites in `circ.ts` (`reverseEasing(circIn)`, `mirrorEasing(circIn)`) — which previously had no purity markers — are now also tree-shakeable. A consumer importing only `circIn` no longer pays for the unused `circOut` / `circInOut` initialiser calls.

`easingDefinitionToFunction` in `utils/map.ts` was left alone — it calls `invariant`, which throws in dev and could be considered observable.

## Measurements

The annotations only affect downstream tree-shaking; they are pass-through for motion-utils' own bundles. Per-file gzipped before/after:

| File | Before | After | Δ |
|---|---|---|---|
| `packages/motion-utils/dist/motion-utils.js` | 1687 | 1687 | 0 |
| `packages/motion-utils/dist/motion-utils.dev.js` | 3776 | 3785 | +9 |
| `packages/motion-utils/dist/es/index.mjs` | 543 | 543 | 0 |
| `packages/motion-utils/dist/cjs/index.js` | 3655 | 3666 | +11 |
| `packages/framer-motion/dist/framer-motion.js` | 59621 | 59621 | 0 |
| `packages/framer-motion/dist/mini.js` | 3352 | 3352 | 0 |
| `packages/framer-motion/dist/dom.js` | 43700 | 43700 | 0 |
| `packages/framer-motion/dist/dom-mini.js` | 4979 | 4979 | 0 |

The `+9`/`+11` on the dev/cjs builds is the annotation text itself — preserved in dist so downstream bundlers (Rollup, esbuild) can act on it. The minified prod bundles and the es entry are unchanged. The win lands in *consumer* bundles, which now drop unused easing initialisers automatically.

## Test plan
- [x] `yarn build`
- [x] `yarn test` — 793 passed, 7 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)