### PR TITLE
Fix drag transform stranded after same-row swap in React 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Undocumented APIs should be considered internal and may change without warning.
 ### Fixed
 
 -   Variants: Re-run keyframe animations when switching between variant labels even when they share identical keyframe arrays.
+-   Drag: Preserve in-flight motion value animations across React 19 reorder unmount/remount so `dragSnapToOrigin` no longer leaves the drag transform stranded after a layout swap.
 
 ## [12.39.0] 2026-05-05
 

--- a/dev/react/src/tests/drag-snap-animate-presence-exit.tsx
+++ b/dev/react/src/tests/drag-snap-animate-presence-exit.tsx
@@ -1,0 +1,56 @@
+/**
+ * Companion to the #3315 fix: exercise drag + dragSnapToOrigin alongside
+ * AnimatePresence exit. The fix removes a synchronous `value.stop()` from
+ * VisualElement.unmount and relies on a deferred auto-stop — this page
+ * lets a Cypress run prove that AnimatePresence exit animations still
+ * complete cleanly while a drag-driven motion-value animation is mid-flight
+ * during the unmount.
+ */
+
+import { useState } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+
+const TILE_SIZE = 80
+
+export const App = () => {
+    const [show, setShow] = useState(true)
+
+    return (
+        <div style={{ padding: 60 }}>
+            <button
+                data-testid="toggle"
+                onClick={() => setShow((s) => !s)}
+                style={{ marginBottom: 20 }}
+            >
+                toggle
+            </button>
+            <div
+                id="container"
+                data-show={show ? "1" : "0"}
+                style={{ position: "relative", width: 300, height: 300 }}
+            >
+                <AnimatePresence>
+                    {show && (
+                        <motion.div
+                            data-testid="tile"
+                            drag
+                            dragSnapToOrigin
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ duration: 0.2 }}
+                            style={{
+                                position: "absolute",
+                                top: 0,
+                                left: 0,
+                                width: TILE_SIZE,
+                                height: TILE_SIZE,
+                                background: "#08f",
+                            }}
+                        />
+                    )}
+                </AnimatePresence>
+            </div>
+        </div>
+    )
+}

--- a/dev/react/src/tests/drag-snap-layout-id-swap.tsx
+++ b/dev/react/src/tests/drag-snap-layout-id-swap.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react"
+import { motion } from "framer-motion"
+
+/**
+ * Regression test for issue #3315.
+ *
+ * Tiles use `drag` + `dragSnapToOrigin` + `layoutId` with absolute
+ * `top`/`left` positioning. When two same-row tiles swap, React 19's
+ * reorder reconciliation briefly unmounts and remounts the dragged tile.
+ * The visual element's unmount used to call `value.stop()` on its owned
+ * motion values, killing the in-flight dragSnapToOrigin animation and
+ * leaving the drag transform stranded — so the tile would render at its
+ * new layout position PLUS the drag offset.
+ */
+
+const TILES_PER_ROW = 3
+const TILE_SIZE = 60
+const GRID_SIZE = TILE_SIZE * TILES_PER_ROW
+
+export const App = () => {
+    const [tiles, setTiles] = useState<{ id: number }[][]>(() => {
+        const t: { id: number }[][] = []
+        for (let i = 0; i < TILES_PER_ROW; i++) {
+            const r: { id: number }[] = []
+            for (let j = 0; j < TILES_PER_ROW; j++) {
+                r.push({ id: i * TILES_PER_ROW + j })
+            }
+            t.push(r)
+        }
+        return t
+    })
+
+    const handleDragEnd = (
+        draggedPos: { x: number; y: number },
+        info: { offset: { x: number; y: number } }
+    ) => {
+        const dropX = draggedPos.x + Math.round(info.offset.x / TILE_SIZE)
+        const dropY = draggedPos.y + Math.round(info.offset.y / TILE_SIZE)
+        if (
+            dropX < 0 ||
+            dropX >= TILES_PER_ROW ||
+            dropY < 0 ||
+            dropY >= TILES_PER_ROW ||
+            (draggedPos.x === dropX && draggedPos.y === dropY)
+        ) {
+            return
+        }
+        const newTiles = tiles.map((row) => [...row])
+        newTiles[dropY][dropX] = tiles[draggedPos.y][draggedPos.x]
+        newTiles[draggedPos.y][draggedPos.x] = tiles[dropY][dropX]
+        setTiles(newTiles)
+    }
+
+    return (
+        <div style={{ padding: 50 }}>
+            <div
+                id="grid"
+                data-tile-state={tiles
+                    .map((row) => row.map((t) => t.id).join(","))
+                    .join("|")}
+                style={{
+                    border: "solid 1px black",
+                    width: GRID_SIZE,
+                    height: GRID_SIZE,
+                    position: "relative",
+                }}
+            >
+                {tiles.map((r, y) =>
+                    r.map((tile, x) => (
+                        <Tile
+                            position={{ x, y }}
+                            tile={tile}
+                            key={tile.id}
+                            id={tile.id}
+                            onDragEnd={handleDragEnd}
+                        />
+                    ))
+                )}
+            </div>
+        </div>
+    )
+}
+
+function Tile({
+    tile,
+    position,
+    id,
+    onDragEnd,
+}: {
+    tile: { id: number }
+    position: { x: number; y: number }
+    id: number
+    onDragEnd: (
+        pos: { x: number; y: number },
+        info: { offset: { x: number; y: number } }
+    ) => void
+}) {
+    const [isDragging, setIsDragging] = useState(false)
+    return (
+        <motion.div
+            data-testid={`tile-${id}`}
+            style={{
+                position: "absolute",
+                border: "solid 1px black",
+                width: TILE_SIZE,
+                height: TILE_SIZE,
+                top: position.y * TILE_SIZE,
+                left: position.x * TILE_SIZE,
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                backgroundColor: "#fff",
+                zIndex: isDragging ? 1 : 0,
+            }}
+            layoutId={String(tile.id)}
+            onAnimationComplete={() => setIsDragging(false)}
+            onAnimationStart={() => setIsDragging(true)}
+            drag
+            dragSnapToOrigin
+            onDragEnd={(_, info) => onDragEnd(position, info)}
+            whileDrag={{ zIndex: 1 }}
+        >
+            {id}
+        </motion.div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/drag-snap-animate-presence-exit.ts
+++ b/packages/framer-motion/cypress/integration/drag-snap-animate-presence-exit.ts
@@ -1,0 +1,52 @@
+/**
+ * Drag + dragSnapToOrigin + AnimatePresence exit interaction (companion
+ * to #3315). After the fix removed VE.unmount's synchronous value.stop(),
+ * we want to confirm that:
+ *   1. AnimatePresence exit animations still complete and tear the tile down.
+ *   2. Toggling the tile back on after a drag yields a clean motion element
+ *      (no stranded drag transform from the previous instance).
+ */
+
+describe("drag + dragSnapToOrigin + AnimatePresence exit", () => {
+    it("exits cleanly after a drag and re-enters without a stranded transform", () => {
+        const initial: { left?: number; top?: number } = {}
+        cy.visit("?test=drag-snap-animate-presence-exit")
+            .wait(200)
+            // Capture the tile's initial layout box so we can compare the
+            // re-entered instance to it later.
+            .get('[data-testid="tile"]')
+            .then(([$el]: any) => {
+                const r = $el.getBoundingClientRect()
+                initial.left = r.left
+                initial.top = r.top
+            })
+            // Drag the tile and release — dragSnapToOrigin animation kicks in.
+            .get('[data-testid="tile"]')
+            .trigger("pointerdown", 10, 10, { force: true })
+            .trigger("pointermove", 20, 10, { force: true })
+            .wait(50)
+            .trigger("pointermove", 60, 10, { force: true })
+            .wait(50)
+            .trigger("pointerup", 60, 10, { force: true })
+            // Toggle off mid-snap to trigger AnimatePresence exit while
+            // the drag motion-value animation is still in flight.
+            .get('[data-testid="toggle"]')
+            .click()
+            .wait(800)
+            // AnimatePresence should have torn the tile down.
+            .get('[data-testid="tile"]')
+            .should("not.exist")
+            // Toggle back on and confirm the new tile renders at the
+            // same layout position as the first instance — no leftover
+            // transform from the previous drag.
+            .get('[data-testid="toggle"]')
+            .click()
+            .wait(500)
+            .get('[data-testid="tile"]')
+            .should(([$el]: any) => {
+                const r = $el.getBoundingClientRect()
+                expect(r.left).to.be.closeTo(initial.left!, 2)
+                expect(r.top).to.be.closeTo(initial.top!, 2)
+            })
+    })
+})

--- a/packages/framer-motion/cypress/integration/drag-snap-layout-id-swap.ts
+++ b/packages/framer-motion/cypress/integration/drag-snap-layout-id-swap.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test for issue #3315.
+ *
+ * Tiles use `drag` + `dragSnapToOrigin` + `layoutId` in an absolutely-
+ * positioned grid. When same-row tiles swap, React 19's reorder
+ * reconciliation briefly unmounts and remounts the dragged component;
+ * if the VisualElement's unmount cancels in-flight motion-value
+ * animations, the dragSnapToOrigin animation dies before remount can
+ * resubscribe and the tile renders at "new layout + stranded drag offset".
+ *
+ * Note: The bug only manifests under React 19's reconciliation. The Cypress
+ * runner targets the React 19 dev app (`cypress.react-19.json`), so the
+ * regression gate is on that config; the React 18 run passes either way.
+ */
+describe("drag + dragSnapToOrigin + layoutId horizontal swap", () => {
+    it("does not strand the drag transform after a same-row swap", () => {
+        cy.visit("?test=drag-snap-layout-id-swap")
+            .wait(200)
+            .get('[data-testid="tile-0"]')
+            .should(([$el]: any) => {
+                const r = $el.getBoundingClientRect()
+                expect(r.left).to.be.closeTo(50, 2)
+                expect(r.top).to.be.closeTo(50, 2)
+            })
+            // Drag tile-0 right ~60px (one column) onto tile-1's slot.
+            // Pointermoves are element-relative; we keep the move small so
+            // the recomputed-as-element-moves coordinate system still lands
+            // the pointer on tile-1.
+            .trigger("pointerdown", 5, 5, { force: true })
+            .trigger("pointermove", 10, 5, { force: true })
+            .wait(50)
+            .trigger("pointermove", 35, 5, { force: true })
+            .wait(50)
+            .trigger("pointerup", 35, 5, { force: true })
+            .wait(2000)
+            .get("#grid")
+            .should(([$grid]: any) => {
+                // Confirm the state-level swap happened.
+                expect($grid.getAttribute("data-tile-state")).to.match(
+                    /^1,0,/
+                )
+            })
+            .get('[data-testid="tile-0"]')
+            .should(([$el]: any) => {
+                const r = $el.getBoundingClientRect()
+                // Tile 0 swapped into column 1: 50 (padding) + 60 (column).
+                // The bug would leave it at ~170 (col 1 + stranded drag).
+                expect(r.left).to.be.closeTo(110, 2)
+                expect(r.top).to.be.closeTo(50, 2)
+            })
+            .get('[data-testid="tile-1"]')
+            .should(([$el]: any) => {
+                const r = $el.getBoundingClientRect()
+                expect(r.left).to.be.closeTo(50, 2)
+                expect(r.top).to.be.closeTo(50, 2)
+            })
+    })
+})

--- a/packages/framer-motion/src/motion/__tests__/unmount-motion-value.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/unmount-motion-value.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Regression coverage for issue #3315.
+ *
+ * `VisualElement.unmount()` used to synchronously stop animations on any
+ * motion value it owned. That broke React 19's reorder reconciliation — the
+ * dragged tile briefly unmounts and remounts, and the synchronous stop
+ * killed the in-flight `dragSnapToOrigin` animation before remount could
+ * resubscribe, leaving the drag transform stranded.
+ *
+ * These tests pin the new behaviour: the synchronous stop is gone, and the
+ * deferred auto-stop in `MotionValue.on("change")` cleanup still runs.
+ */
+
+import { createRef } from "react"
+import { frame, visualElementStore } from "motion-dom"
+import { motion } from "../../render/components/motion"
+import { render } from "../../jest.setup"
+import { nextFrame } from "../../gestures/__tests__/utils"
+
+describe("motion value lifecycle on unmount (#3315)", () => {
+    test("does not synchronously stop animations on VE-owned motion values", async () => {
+        const ref = createRef<HTMLDivElement>()
+
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                animate={{ x: 100 }}
+                transition={{ duration: 10, ease: "linear" }}
+            />
+        )
+
+        const { unmount, rerender } = render(<Component />)
+        rerender(<Component />)
+        await nextFrame()
+
+        const ve = visualElementStore.get(ref.current!)!
+        const xValue = ve.getValue("x")!
+
+        // Confirm the test setup is exercising a VE-owned motion value
+        // (this is the only path that hit the old synchronous stop).
+        expect(xValue.owner).toBe(ve)
+        expect(xValue.isAnimating()).toBe(true)
+
+        // Subscribe so the deferred auto-stop won't run when the VE
+        // unmounts — this simulates the React 19 remount case where a new
+        // VisualElement re-binds to the motion value before the next frame.
+        const externalSubscriber = jest.fn()
+        const stopListening = xValue.on("change", externalSubscriber)
+
+        unmount()
+
+        // Pre-#3315 this would be false: VE.unmount called value.stop()
+        // synchronously and killed the animation. We need it true so a
+        // remount that re-subscribes can pick the animation up.
+        expect(xValue.isAnimating()).toBe(true)
+
+        stopListening()
+    })
+
+    test("deferred auto-stop fires on next frame when nothing resubscribes", async () => {
+        const ref = createRef<HTMLDivElement>()
+
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                animate={{ x: 100 }}
+                transition={{ duration: 10, ease: "linear" }}
+            />
+        )
+
+        const { unmount, rerender } = render(<Component />)
+        rerender(<Component />)
+        await nextFrame()
+
+        const ve = visualElementStore.get(ref.current!)!
+        const xValue = ve.getValue("x")!
+        expect(xValue.isAnimating()).toBe(true)
+
+        unmount()
+
+        // Synchronously, animation is still running...
+        expect(xValue.isAnimating()).toBe(true)
+
+        // ...but with no listener attached, the deferred auto-stop runs on
+        // the next frame and the animation is cleaned up. This is the path
+        // that prevents leaks for genuinely permanent unmounts.
+        await nextFrame()
+        expect(xValue.isAnimating()).toBe(false)
+    })
+
+    test("animation can survive an unmount-then-resubscribe within a single frame", async () => {
+        const ref = createRef<HTMLDivElement>()
+
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                animate={{ x: 100 }}
+                transition={{ duration: 10, ease: "linear" }}
+            />
+        )
+
+        const { unmount, rerender } = render(<Component />)
+        rerender(<Component />)
+        await nextFrame()
+
+        const ve = visualElementStore.get(ref.current!)!
+        const xValue = ve.getValue("x")!
+        expect(xValue.isAnimating()).toBe(true)
+
+        unmount()
+
+        // Simulate a remount re-establishing a change listener before the
+        // deferred auto-stop callback runs.
+        const resubscribe = jest.fn()
+        const stopListening = xValue.on("change", resubscribe)
+
+        // Wait long enough for the deferred frame.read callback to fire.
+        await nextFrame()
+
+        // Because a listener is now present, the auto-stop must skip and
+        // the animation should keep ticking.
+        expect(xValue.isAnimating()).toBe(true)
+        // The motion value should still be reporting changes after the
+        // simulated remount.
+        const valueAfterRemount = xValue.get()
+        await new Promise<void>((resolve) => frame.postRender(() => resolve()))
+        expect(xValue.get()).not.toBe(valueAfterRemount)
+
+        stopListening()
+    })
+})

--- a/packages/motion-dom/src/render/VisualElement.ts
+++ b/packages/motion-dom/src/render/VisualElement.ts
@@ -602,7 +602,8 @@ export abstract class VisualElement<
         this.valueSubscriptions.set(key, () => {
             removeOnChange()
             if (removeSyncCheck) removeSyncCheck()
-            if (value.owner) value.stop()
+            // Defer to MotionValue.on("change") auto-stop so React 19 remounts
+            // can resubscribe before the animation is cancelled (#3315).
         })
     }
 


### PR DESCRIPTION
## Summary

- Fixes #3315 — when `motion.div drag dragSnapToOrigin layoutId` tiles swap horizontally in React 19, the drag transform was being stranded over the new layout position.
- Root cause: React 19's list-reorder reconciliation briefly unmounts/remounts the dragged component. `VisualElement`'s motion-value unsubscribe callback was synchronously calling `value.stop()`, which killed the in-flight `dragSnapToOrigin` animation before remount could re-subscribe. The motion value froze mid-animation, leaving the transform stuck.
- Fix: drop the synchronous `value.stop()` and rely on `MotionValue.on("change")`'s existing deferred auto-stop (runs on the next read frame), giving the remount a chance to re-subscribe so the animation runs to completion.

The bug only reproduces under React 19's reconciliation behaviour. The new Cypress spec is gated on `cypress.react-19.json`; it fails reliably against the un-fixed `main` and passes with the fix.

## Test plan

- [x] `yarn test` — all 793 unit tests pass.
- [x] New Cypress regression spec `drag-snap-layout-id-swap.ts` passes on React 19 with the fix.
- [x] New spec **fails** against `main` without the fix (`expected 145.6 to be close to 110 ± 2`), confirming it's a real regression gate.
- [x] Existing drag suite (`drag.ts`, `drag-to-reorder.ts`, `drag-layout-reorder-strict.ts`, `drag-momentum.ts`) — 33 passing on React 19, 32 on React 18.
- [x] Spot-checked layout suite (`layout-cancelled-finishes.ts`, `animate-layout-timing.ts`, `animate-presence-layout.ts`) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)