### PR TITLE
fix: make Reorder compatible with LazyMotion

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -4,7 +4,7 @@ import { invariant } from "motion-utils"
 import * as React from "react"
 import { forwardRef, FunctionComponent, JSX, useEffect, useRef } from "react"
 import { ReorderContext } from "../../context/ReorderContext"
-import { motion } from "../../render/components/motion/proxy"
+import * as m from "../../render/components/m/namespace"
 import { HTMLMotionProps } from "../../render/html/types"
 import { useConstant } from "../../utils/use-constant"
 import {
@@ -84,7 +84,7 @@ export function ReorderGroupComponent<
     externalRef?: React.ForwardedRef<any>
 ): JSX.Element {
     const Component = useConstant(
-        () => motion[as as keyof typeof motion]
+        () => m[as as keyof typeof m]
     ) as FunctionComponent<
         React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
     >
@@ -166,7 +166,7 @@ export function ReorderGroupComponent<
     }
 
     return (
-        <Component {...props} style={groupStyle} ref={setRef} ignoreStrict>
+        <Component {...props} style={groupStyle} ref={setRef}>
             <ReorderContext.Provider value={context}>
                 {children}
             </ReorderContext.Provider>

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -5,7 +5,7 @@ import { invariant } from "motion-utils"
 import * as React from "react"
 import { forwardRef, FunctionComponent, useContext } from "react"
 import { ReorderContext } from "../../context/ReorderContext"
-import { motion } from "../../render/components/motion/proxy"
+import * as m from "../../render/components/m/namespace"
 import { HTMLMotionProps } from "../../render/html/types"
 import { useConstant } from "../../utils/use-constant"
 import { useMotionValue } from "../../value/use-motion-value"
@@ -72,7 +72,7 @@ export function ReorderItemComponent<
     externalRef?: React.ForwardedRef<any>
 ): React.JSX.Element {
     const Component = useConstant(
-        () => motion[as as keyof typeof motion]
+        () => m[as as keyof typeof m]
     ) as FunctionComponent<
         React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
     >
@@ -126,7 +126,6 @@ export function ReorderItemComponent<
                 registerItem(value, measured)
             }}
             ref={externalRef}
-            ignoreStrict
         >
             {children}
         </Component>


### PR DESCRIPTION
## Summary

`Reorder.Group` and `Reorder.Item` imported components from the full `motion` proxy and passed `ignoreStrict`, which means importing Reorder could eagerly include the full feature bundle and bypass `LazyMotion strict` checks.

This switches Reorder internals to the lightweight `m` component namespace and removes the strict-mode bypass so Reorder behaves like other LazyMotion-compatible components.

Fixes #2232.

## Validation

- `./node_modules/.bin/eslint packages/framer-motion/src/components/Reorder/Group.tsx packages/framer-motion/src/components/Reorder/Item.tsx` reported one existing `react-compiler` warning in `Item.tsx` and no errors
- `./node_modules/.bin/jest --runInBand --runTestsByPath packages/framer-motion/src/components/Reorder/__tests__/index.test.tsx --config <temporary Windows resolver config>` passed 3 tests