### PR TITLE
Add reducedMotion option to useAnimate

### DIFF
--- a/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
+++ b/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom"
 import { render } from "@testing-library/react"
 import { useEffect } from "react"
 import { MotionConfig } from "../../../components/MotionConfig"
+import { nextFrame } from "../../../gestures/__tests__/utils"
 import { useAnimate } from "../use-animate"
 
 describe("useAnimate", () => {
@@ -115,6 +116,80 @@ describe("useAnimate", () => {
         })
 
         expect(frameCount).toEqual(3)
+    })
+
+    test("reducedMotion='always' option makes transforms animate instantly", async () => {
+        const result = await new Promise<{ x: string; opacity: string }>(
+            (resolve) => {
+                const Component = () => {
+                    const [scope, animate] = useAnimate<HTMLDivElement>({
+                        reducedMotion: "always",
+                    })
+
+                    useEffect(() => {
+                        animate(
+                            scope.current,
+                            { x: 100, opacity: 1 },
+                            { duration: 2 }
+                        )
+
+                        nextFrame().then(() => {
+                            const style = getComputedStyle(scope.current)
+                            resolve({
+                                x: style.transform,
+                                opacity: style.opacity,
+                            })
+                        })
+                    })
+
+                    return <div ref={scope} />
+                }
+
+                render(<Component />)
+            }
+        )
+
+        expect(result.x).toContain("translateX(100px)")
+        expect(result.opacity).not.toEqual("1")
+    })
+
+    test("reducedMotion='never' option overrides parent MotionConfig reducedMotion='always'", async () => {
+        const result = await new Promise<{ x: string; opacity: string }>(
+            (resolve) => {
+                const Component = () => {
+                    const [scope, animate] = useAnimate<HTMLDivElement>({
+                        reducedMotion: "never",
+                    })
+
+                    useEffect(() => {
+                        animate(
+                            scope.current,
+                            { x: 100, opacity: 1 },
+                            { duration: 2 }
+                        )
+
+                        nextFrame().then(() => {
+                            const style = getComputedStyle(scope.current)
+                            resolve({
+                                x: style.transform,
+                                opacity: style.opacity,
+                            })
+                        })
+                    })
+
+                    return <div ref={scope} />
+                }
+
+                render(
+                    <MotionConfig reducedMotion="always">
+                        <Component />
+                    </MotionConfig>
+                )
+            }
+        )
+
+        expect(result.x).not.toContain("translateX(100px)")
+        expect(result.opacity).not.toEqual("1")
     })
 
     test("Applies final value instantly when MotionConfig skipAnimations is true", () => {

--- a/packages/framer-motion/src/animation/hooks/use-animate.ts
+++ b/packages/framer-motion/src/animation/hooks/use-animate.ts
@@ -5,16 +5,34 @@ import { AnimationScope } from "motion-dom"
 import { useConstant } from "../../utils/use-constant"
 import { useUnmountEffect } from "../../utils/use-unmount-effect"
 import { useReducedMotionConfig } from "../../utils/reduced-motion/use-reduced-motion-config"
-import { MotionConfigContext } from "../../context/MotionConfigContext"
+import {
+    MotionConfigContext,
+    ReducedMotionConfig,
+} from "../../context/MotionConfigContext"
 import { createScopedAnimate } from "../animate"
 
-export function useAnimate<T extends Element = any>() {
+export interface UseAnimateOptions {
+    /**
+     * Override the inherited `MotionConfig` reducedMotion setting for animations
+     * created by this `useAnimate` instance.
+     *
+     * - `"always"`: Skip transform/layout animations (instant transition).
+     * - `"never"`: Always animate transforms/layout, even if the user has
+     *   `prefers-reduced-motion` enabled.
+     * - `"user"`: Use the device preference.
+     */
+    reducedMotion?: ReducedMotionConfig
+}
+
+export function useAnimate<T extends Element = any>(
+    { reducedMotion }: UseAnimateOptions = {}
+) {
     const scope: AnimationScope<T> = useConstant(() => ({
         current: null!, // Will be hydrated by React
         animations: [],
     }))
 
-    const reduceMotion = useReducedMotionConfig() ?? undefined
+    const reduceMotion = useReducedMotionConfig(reducedMotion) ?? undefined
     const { skipAnimations } = useContext(MotionConfigContext)
 
     const animate = useMemo(

--- a/packages/framer-motion/src/utils/reduced-motion/use-reduced-motion-config.ts
+++ b/packages/framer-motion/src/utils/reduced-motion/use-reduced-motion-config.ts
@@ -1,12 +1,17 @@
 "use client"
 
 import { useContext } from "react"
-import { MotionConfigContext } from "../../context/MotionConfigContext"
+import {
+    MotionConfigContext,
+    ReducedMotionConfig,
+} from "../../context/MotionConfigContext"
 import { useReducedMotion } from "./use-reduced-motion"
 
-export function useReducedMotionConfig() {
+export function useReducedMotionConfig(override?: ReducedMotionConfig) {
     const reducedMotionPreference = useReducedMotion()
-    const { reducedMotion } = useContext(MotionConfigContext)
+    const { reducedMotion: contextReducedMotion } =
+        useContext(MotionConfigContext)
+    const reducedMotion = override ?? contextReducedMotion
 
     if (reducedMotion === "never") {
         return false


### PR DESCRIPTION
## Summary
- Adds an options argument to `useAnimate` mirroring `MotionConfig`'s `reducedMotion` prop (`"always" | "never" | "user"`).
- Threads the override through `useReducedMotionConfig` so the hook can opt out of (or into) reduced-motion handling regardless of the inherited context.

```jsx
const [scope, animate] = useAnimate({ reducedMotion: "never" })
```

## Why
Per #2837, there's no way to override `MotionConfig`'s `reducedMotion` setting for a specific `useAnimate` instance. The reporter noted that wrapping the scope in a `MotionConfig` doesn't help — the hook reads context where it's called, not where the scope element is rendered. This adds the same escape hatch that motion components get via nested `MotionConfig`.

## Fixes
Fixes #2837

## Test plan
- [x] Unit test: `reducedMotion: "always"` instantly completes transform animations created via `useAnimate`.
- [x] Unit test: `reducedMotion: "never"` overrides a parent `<MotionConfig reducedMotion="always">`.
- [x] Existing `useAnimate` / `MotionConfig` / `useReducedMotionConfig` tests still pass (802/802).
- [x] `yarn build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)