### PR TITLE
Fix drag starting from initial value under AnimatePresence initial={false}

### DIFF
--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -536,9 +536,7 @@ export class VisualElementDragControls {
             ? externalMotionValue
             : this.visualElement.getValue(
                   axis,
-                  (props.initial
-                      ? props.initial[axis as keyof typeof props.initial]
-                      : undefined) || 0
+                  this.visualElement.latestValues[axis] ?? 0
               )
     }
 

--- a/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import {
+    AnimatePresence,
     BoundingBox,
     motion,
     motionValue,
@@ -1214,5 +1215,37 @@ describe("keyboard accessible elements", () => {
 
         expect(onDragStart).toBeCalledTimes(1)
         expect(x.get()).toBeGreaterThanOrEqual(100)
+    })
+})
+
+describe("drag with AnimatePresence initial={false}", () => {
+    test("drag starts from animate value, not initial value", async () => {
+        const Component = () => (
+            <AnimatePresence initial={false}>
+                <MockDrag>
+                    <motion.div
+                        data-testid="draggable"
+                        drag="y"
+                        dragMomentum={false}
+                        initial={{ y: 200 }}
+                        animate={{ y: 0 }}
+                    />
+                </MockDrag>
+            </AnimatePresence>
+        )
+
+        const { getByTestId, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        const pointer = await drag(getByTestId("draggable")).to(0, 10)
+
+        // After dragging down 10px, transform should reflect y = 10
+        // (drag offset from animate.y = 0), not y = 210 (drag offset from
+        // initial.y = 200).
+        expect(getByTestId("draggable")).toHaveStyle(
+            "transform: translateY(10px)"
+        )
+
+        pointer.end()
     })
 })


### PR DESCRIPTION
## Summary

Fixes #2831.

A `motion` component with `drag` enabled, rendered as a child of `<AnimatePresence initial={false}>`, would start its drag animation from its `initial` styles instead of the visible `animate` styles on the first drag.

## Cause

When drag starts, `VisualElementDragControls.getAxisMotionValue(axis)` calls `visualElement.getValue(axis, fallback)`. If no motion value exists for `axis` yet (e.g. because `AnimatePresence initial={false}` blocked the initial animation, so no animation has run), it creates one with the fallback.

The fallback was `props.initial[axis]` — which is the value AnimatePresence specifically told us to skip. So the new motion value started at `initial.y` (e.g. `"50%"`), and the drag origin was anchored there, causing the visible element to jump on first drag.

## Fix

Use `visualElement.latestValues[axis]` as the fallback. `latestValues` already reflects the actually-rendered values — `makeLatestValues` picks `animate` instead of `initial` when `presenceContext.initial === false` (and the same when `initial={false}` is set on the motion component directly).

## Test plan

- [x] Added Jest test covering the exact scenario from the issue (motion.div with `initial={{ y: 200 }}`, `animate={{ y: 0 }}`, `drag="y"` inside `<AnimatePresence initial={false}>`)
- [x] Test fails on `main` (drag yields `translateY(210px)` — drag offset added to `initial.y`)
- [x] Test passes after the fix (drag yields `translateY(10px)` — drag offset added to `animate.y`)
- [x] `yarn build` passes
- [x] `yarn test` passes (794 tests)