### PR TITLE
Add regression test for motion.div + position:fixed (#2833)

### DIFF
--- a/dev/react/src/tests/issue-2833-fixed-position.tsx
+++ b/dev/react/src/tests/issue-2833-fixed-position.tsx
@@ -1,0 +1,67 @@
+import { motion } from "framer-motion"
+
+/**
+ * Regression test for #2833.
+ *
+ * React-select with menuPosition="fixed" relies on the menu being positioned
+ * relative to the viewport, not to its ancestors. CSS spec: an ancestor with
+ * `transform`, `perspective`, `filter`, `backdrop-filter`, or `will-change`
+ * (containing those properties) establishes a containing block for fixed
+ * descendants — breaking that assumption.
+ *
+ * motion.div should not apply any of those by default, even when transform
+ * animations are configured via animate/whileHover/whileTap.
+ */
+export const App = () => {
+    const variant =
+        new URLSearchParams(window.location.search).get("variant") ?? "plain"
+
+    const child = (
+        <div
+            id="fixed-child"
+            style={{
+                position: "fixed",
+                top: 10,
+                left: 10,
+                width: 50,
+                height: 50,
+                background: "red",
+            }}
+        />
+    )
+
+    let parent
+    if (variant === "while-hover") {
+        parent = (
+            <motion.div id="parent" whileHover={{ scale: 1.1 }}>
+                {child}
+            </motion.div>
+        )
+    } else if (variant === "while-tap") {
+        parent = (
+            <motion.div id="parent" whileTap={{ scale: 0.9 }}>
+                {child}
+            </motion.div>
+        )
+    } else if (variant === "animate-transform") {
+        parent = (
+            <motion.div id="parent" animate={{ x: 0, y: 0 }}>
+                {child}
+            </motion.div>
+        )
+    } else if (variant === "initial-transform") {
+        parent = (
+            <motion.div
+                id="parent"
+                initial={{ scale: 1 }}
+                animate={{ scale: 1 }}
+            >
+                {child}
+            </motion.div>
+        )
+    } else {
+        parent = <motion.div id="parent">{child}</motion.div>
+    }
+
+    return <div style={{ padding: 200 }}>{parent}</div>
+}

--- a/packages/framer-motion/cypress/integration/issue-2833-fixed-position.ts
+++ b/packages/framer-motion/cypress/integration/issue-2833-fixed-position.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for #2833.
+ *
+ * React-select with menuPosition="fixed" was rendering in the wrong position
+ * because motion.div applied will-change: transform automatically, which
+ * establishes a CSS containing block for position: fixed descendants. The
+ * auto will-change behaviour was removed but plain transform/filter/etc.
+ * should also never be applied by default.
+ */
+const variants = [
+    "plain",
+    "while-hover",
+    "while-tap",
+    "animate-transform",
+    "initial-transform",
+]
+
+describe("position: fixed children inside motion.div (#2833)", () => {
+    for (const variant of variants) {
+        it(`motion.div does not establish a containing block (variant=${variant})`, () => {
+            cy.visit(`?test=issue-2833-fixed-position&variant=${variant}`)
+
+            cy.get("#parent").then(($el) => {
+                const cs = getComputedStyle($el[0] as HTMLElement)
+                expect(cs.transform).to.equal("none")
+                expect(cs.perspective).to.equal("none")
+                expect(cs.filter).to.equal("none")
+                // willChange of "transform"/"perspective"/"filter" would also
+                // establish a containing block.
+                expect(cs.willChange).to.equal("auto")
+            })
+
+            // The fixed-positioned child should land at viewport (10, 10),
+            // not offset by the wrapper's 200px padding.
+            cy.get("#fixed-child").then(($el) => {
+                const rect = ($el[0] as HTMLElement).getBoundingClientRect()
+                expect(rect.top).to.equal(10)
+                expect(rect.left).to.equal(10)
+            })
+        })
+    }
+})


### PR DESCRIPTION
## Summary

- Reproduces and guards #2833: `react-select` with `menuPosition=\"fixed\"` rendered in the wrong position when wrapped in `motion.div`.
- Root cause was the auto `will-change: transform` that motion components used to apply — `will-change` containing `transform`/`perspective`/`filter` establishes a CSS containing block for `position: fixed` descendants, so react-select's viewport coordinates were re-interpreted relative to `motion.div`.
- The behaviour was already removed in [f5c89e8e4 \"Removing will-change\"](https://github.com/motiondivision/motion/commit/f5c89e8e4). This PR adds a Cypress regression test so it doesn't come back.

## Test plan

The new test (`cypress/integration/issue-2833-fixed-position.ts`) asserts, for several common `motion.div` configurations (plain, `whileHover`, `whileTap`, `animate`, `initial`):

- Computed `transform`, `perspective`, `filter` are all `none`.
- Computed `willChange` is `auto`.
- A `position: fixed` child set at `top: 10, left: 10` lands at viewport `(10, 10)` regardless of the wrapper's `padding: 200`.

Verified locally:

- [x] `yarn build` clean
- [x] `yarn test` — 793 passing
- [x] Cypress against React 18 — 5/5 passing
- [x] Cypress against React 19 — 5/5 passing
- [x] Confirmed the test fails when `willChange: transform` is forced back onto `motion.div`

Fixes #2833

🤖 Generated with [Claude Code](https://claude.com/claude-code)