### PR TITLE
fix(drag): refresh root scroll before measuring ref constraints (#2829)

### DIFF
--- a/dev/react/src/tests/drag-ref-constraints-absolute-scrolled.tsx
+++ b/dev/react/src/tests/drag-ref-constraints-absolute-scrolled.tsx
@@ -1,0 +1,56 @@
+import { motion } from "framer-motion"
+import { useRef, useLayoutEffect } from "react"
+
+/**
+ * Test page for issue #2829: When dragConstraints is set to a ref pointing
+ * to a viewport-sized element (`position: absolute; inset: 0`), drag should
+ * work across the full constraint area regardless of initial scroll position.
+ *
+ * The page is tall enough to scroll. We scroll the window in a layout effect
+ * to simulate a page being refreshed after the user had scrolled, which is
+ * the exact scenario the bug reporter described.
+ */
+export const App = () => {
+    const constraintsRef = useRef<HTMLDivElement>(null)
+
+    const params = new URLSearchParams(window.location.search)
+    const initialScroll = Number(params.get("scroll") || "300")
+
+    useLayoutEffect(() => {
+        window.scrollTo(0, initialScroll)
+    }, [initialScroll])
+
+    return (
+        <div style={{ height: 3000, margin: 0, padding: 0 }}>
+            <div
+                id="constraints"
+                ref={constraintsRef}
+                style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    background: "rgba(0, 0, 255, 0.1)",
+                }}
+            >
+                <motion.div
+                    id="box"
+                    data-testid="draggable"
+                    drag
+                    dragConstraints={constraintsRef}
+                    dragElastic={0}
+                    dragMomentum={false}
+                    style={{
+                        width: 50,
+                        height: 50,
+                        background: "red",
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                    }}
+                />
+            </div>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/drag-ref-constraints-absolute-scrolled.ts
+++ b/packages/framer-motion/cypress/integration/drag-ref-constraints-absolute-scrolled.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for issue #2829: Drag with ref-based constraints on a viewport-sized
+ * element (`position: absolute; inset: 0`) should allow dragging to the bottom
+ * of the visible viewport, even when the page is loaded with scroll restored.
+ *
+ * The test page scrolls the window in a layout effect before drag is wired up,
+ * mimicking the browser restoring scroll position on refresh.
+ */
+describe("Drag with ref constraints on absolute element after scroll", () => {
+    it("Allows dragging to the visible bottom of the viewport after scroll", () => {
+        cy.viewport(1000, 800)
+            .visit("?test=drag-ref-constraints-absolute-scrolled&scroll=300")
+            .wait(300)
+            .window()
+            .then((win) => {
+                expect(win.scrollY).to.be.greaterThan(0)
+            })
+            .get("[data-testid='draggable']")
+            .trigger("pointerdown", 5, 5, { force: true })
+            .trigger("pointermove", 10, 10, { force: true })
+            .wait(50)
+            .trigger("pointermove", 900, 1500, { force: true })
+            .wait(50)
+            .trigger("pointerup", { force: true })
+            .wait(100)
+            .should(($el: any) => {
+                const el = $el[0] as HTMLDivElement
+                const rect = el.getBoundingClientRect()
+                // viewport: 1000x800, scroll: 300, box: 50x50
+                // Constraint is `position: absolute; inset: 0` (viewport-sized
+                // at the document origin). After the page is loaded scrolled,
+                // the visible portion of the constraint spans viewport y ∈
+                // [0, 500]. Before the fix, drag constraints were computed
+                // with a stale scroll offset, clamping the box's bottom to
+                // ~200 (= viewportH - 2*scrollY - boxH). With the fix, the
+                // box should reach the constraint's visible bottom (~500).
+                expect(rect.bottom).to.be.closeTo(500, 5)
+            })
+    })
+})

--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -410,6 +410,21 @@ export class VisualElementDragControls {
         // TODO
         if (!projection || !projection.layout) return false
 
+        /**
+         * Refresh the root scroll offset so the constraint's viewport box
+         * translates to correct page coordinates. The scroll captured at
+         * drag mount can be stale if the document was scrolled afterwards —
+         * e.g. via the browser restoring scroll on refresh, or an ancestor
+         * layout effect running after this element's mount (#2829).
+         *
+         * Clear the cached scroll first so `updateScroll` bypasses its
+         * per-animationId cache and re-reads the live value.
+         */
+        if (projection.root) {
+            projection.root.scroll = undefined
+            projection.root.updateScroll()
+        }
+
         const constraintsBox = measurePageBox(
             constraintsElement,
             projection.root!,


### PR DESCRIPTION
## Summary

- When `dragConstraints` is a ref to a viewport-sized element (e.g. `position: absolute; inset: 0`) and the document is already scrolled when the drag mounts, the constraints are computed with a stale scroll offset. The draggable area shrinks by roughly the scroll amount — the user reported they could no longer drag to the bottom of the viewport after refreshing on a scrolled page.
- Root cause: drag setup runs in a layout effect, calls `projection.root.updateScroll()` once, and then schedules `measureDragConstraints` via `frame.read`. If scroll changes in between (browser restoring scroll on refresh, or an ancestor's layout effect scrolling), the cached root scroll is wrong when the constraint element's viewport box is translated to page coords.
- Fix: clear and re-measure `projection.root.scroll` inside `resolveRefConstraints` so the page-coord translation uses the live scroll offset. `projection.updateScroll`'s per-animationId cache made the obvious "just call updateScroll again" a no-op, so the cached value is cleared first.

## Test plan

- [x] New Cypress test `drag-ref-constraints-absolute-scrolled` reproduces the bug: pre-scroll the window in a layout effect, drag a `motion.div` inside a `position: absolute; inset: 0` ref constraint, assert the box reaches the visible bottom of the viewport. Fails without the fix (`expected 200 to be close to 500`), passes with it.
- [x] All existing drag Cypress tests pass (92/92) on React 18.
- [x] New test passes on React 19.
- [x] `yarn test` passes (793 unit tests).

Fixes #2829

🤖 Generated with [Claude Code](https://claude.com/claude-code)