### PR TITLE
Add dragSnapToCursor prop to motion components

### DIFF
--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -657,7 +657,11 @@ export class VisualElementDragControls {
             element,
             "pointerdown",
             (event) => {
-                const { drag, dragListener = true } = this.getProps()
+                const {
+                    drag,
+                    dragListener = true,
+                    dragSnapToCursor,
+                } = this.getProps()
                 const target = event.target as Element
 
                 /**
@@ -672,7 +676,7 @@ export class VisualElementDragControls {
                     target !== element && isElementTextInput(target)
 
                 if (drag && dragListener && !isClickingTextInputChild) {
-                    this.start(event)
+                    this.start(event, { snapToCursor: dragSnapToCursor })
                 }
             }
         )

--- a/packages/framer-motion/src/gestures/drag/__tests__/use-drag-controls.test.tsx
+++ b/packages/framer-motion/src/gestures/drag/__tests__/use-drag-controls.test.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { motion, useDragControls, DragControls, motionValue } from "../../../"
 import { render } from "../../../jest.setup"
 import { nextFrame } from "../../__tests__/utils"
+import { VisualElementDragControls } from "../VisualElementDragControls"
 import { MockDrag, drag } from "./utils"
 
 describe("useDragControls", () => {
@@ -207,5 +208,69 @@ describe("useDragControls", () => {
         expect(y.get()).toBeCloseTo(yAfterFirstSnap, 0)
 
         pointer2.end()
+    })
+})
+
+describe("dragSnapToCursor prop", () => {
+    test("forwards snapToCursor option to start when prop is true", async () => {
+        const startSpy = jest.spyOn(
+            VisualElementDragControls.prototype,
+            "start"
+        )
+
+        const Component = () => (
+            <MockDrag>
+                <motion.div
+                    drag
+                    dragSnapToCursor
+                    data-testid="draggable"
+                />
+            </MockDrag>
+        )
+
+        const { rerender, getByTestId } = render(<Component />)
+        rerender(<Component />)
+
+        startSpy.mockClear()
+
+        const pointer = await drag(getByTestId("draggable")).to(50, 50)
+        pointer.end()
+        await nextFrame()
+
+        expect(startSpy).toHaveBeenCalled()
+        const [, options] = startSpy.mock.calls[0]
+        expect(options).toEqual(
+            expect.objectContaining({ snapToCursor: true })
+        )
+
+        startSpy.mockRestore()
+    })
+
+    test("does not forward snapToCursor option when prop is not set", async () => {
+        const startSpy = jest.spyOn(
+            VisualElementDragControls.prototype,
+            "start"
+        )
+
+        const Component = () => (
+            <MockDrag>
+                <motion.div drag data-testid="draggable" />
+            </MockDrag>
+        )
+
+        const { rerender, getByTestId } = render(<Component />)
+        rerender(<Component />)
+
+        startSpy.mockClear()
+
+        const pointer = await drag(getByTestId("draggable")).to(50, 50)
+        pointer.end()
+        await nextFrame()
+
+        expect(startSpy).toHaveBeenCalled()
+        const [, options] = startSpy.mock.calls[0]
+        expect(options?.snapToCursor).toBeFalsy()
+
+        startSpy.mockRestore()
     })
 })

--- a/packages/motion-dom/src/node/types.ts
+++ b/packages/motion-dom/src/node/types.ts
@@ -734,6 +734,18 @@ export interface MotionNodeDraggableOptions {
     dragSnapToOrigin?: boolean | "x" | "y"
 
     /**
+     * If `true`, the element will snap so that the cursor is centered on it
+     * when a drag gesture starts. This is the equivalent of passing
+     * `{ snapToCursor: true }` to a `dragControls.start()` call but works
+     * for any drag-enabled motion component.
+     *
+     * ```jsx
+     * <motion.div drag dragSnapToCursor />
+     * ```
+     */
+    dragSnapToCursor?: boolean
+
+    /**
      * By default, if `drag` is defined on a component then an event listener will be attached
      * to automatically initiate dragging when a user presses down on it.
      *


### PR DESCRIPTION
## Summary

- Adds a new `dragSnapToCursor` prop to drag-enabled motion components, exposing the snap-to-cursor behavior previously only available via `dragControls.start(event, { snapToCursor: true })`.
- Lets `dragSnapToCursor` and `dragSnapToOrigin` be declared together on the same component (the previous `dragControls`-only path forced you to forgo declarative `dragSnapToOrigin`).

```jsx
<motion.div drag dragSnapToCursor dragSnapToOrigin />
```

## Cause

`VisualElementDragControls.addListeners` attached a `pointerdown` handler that called `this.start(event)` with no options, so the prop had no way to influence behavior — `snapToCursor` was only ever set when the user passed it explicitly to `dragControls.start`.

## Fix

Read `dragSnapToCursor` from props in the `pointerdown` handler and forward it as `{ snapToCursor: dragSnapToCursor }` to `this.start(event, ...)`. Added a public type field on `MotionNodeDraggableOptions` so the prop is accepted.

## Test plan

- [x] Added unit tests asserting `start` is invoked with `{ snapToCursor: true }` when the prop is set, and without the option when it isn't.
- [x] `yarn build` succeeds.
- [x] `yarn test` — all 778 unit tests pass.

Fixes #2677