### PR TITLE
Add regression test for accordion rapid-click exit animation (#2674)

### DIFF
--- a/dev/react/src/tests/animate-presence-accordion-rapid.tsx
+++ b/dev/react/src/tests/animate-presence-accordion-rapid.tsx
@@ -1,0 +1,58 @@
+import { AnimatePresence, motion } from "framer-motion"
+import { useState } from "react"
+
+const items = [
+    { id: "a", title: "Item A" },
+    { id: "b", title: "Item B" },
+    { id: "c", title: "Item C" },
+]
+
+function AccordionItem({ id, title }: { id: string; title: string }) {
+    const [open, setOpen] = useState(false)
+
+    return (
+        <div>
+            <button
+                className="trigger"
+                data-id={id}
+                onClick={() => setOpen((o) => !o)}
+            >
+                {title}
+            </button>
+            <AnimatePresence initial={false}>
+                {open && (
+                    <motion.section
+                        key="content"
+                        data-panel={id}
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{
+                            type: "tween",
+                            ease: "linear",
+                            duration: 0.5,
+                        }}
+                        style={{ overflow: "hidden" }}
+                    >
+                        <div
+                            data-content={id}
+                            style={{ padding: 20, height: 100 }}
+                        >
+                            Content for {title}
+                        </div>
+                    </motion.section>
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}
+
+export const App = () => {
+    return (
+        <div id="accordion" style={{ width: 400 }}>
+            {items.map((item) => (
+                <AccordionItem key={item.id} id={item.id} title={item.title} />
+            ))}
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-presence-accordion-rapid.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-accordion-rapid.ts
@@ -1,0 +1,84 @@
+describe("AnimatePresence accordion rapid click (#2674)", () => {
+    it("Toggling open mid-exit leaves the panel visible at full height", () => {
+        cy.visit("?test=animate-presence-accordion-rapid")
+            .wait(200)
+            .get('[data-panel="a"]')
+            .should("not.exist")
+            // Open
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            // Wait for full open animation
+            .wait(800)
+            // Close
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            // Mid-exit (250ms into 500ms exit), re-open
+            .wait(250)
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            // Wait for animation to settle
+            .wait(1500)
+            // Panel should exist at full height
+            .get('[data-panel="a"]')
+            .should("exist")
+            .then(($el: any) => {
+                const height = parseFloat(
+                    getComputedStyle($el[0] as HTMLElement).height
+                )
+                const opacity = parseFloat(
+                    getComputedStyle($el[0] as HTMLElement).opacity
+                )
+                expect(height).to.be.greaterThan(100)
+                expect(opacity).to.equal(1)
+            })
+    })
+
+    it("Toggling closed mid-enter removes the panel", () => {
+        cy.visit("?test=animate-presence-accordion-rapid")
+            .wait(200)
+            // Open
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            // Mid-enter (250ms into 500ms enter), close
+            .wait(250)
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            // Wait for exit to finish
+            .wait(1500)
+            .get('[data-panel="a"]')
+            .should("not.exist")
+    })
+
+    it("Rapidly toggling many times ends in correct state (open)", () => {
+        cy.visit("?test=animate-presence-accordion-rapid")
+            .wait(200)
+            // 5 rapid clicks → ends open
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            .wait(50)
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            .wait(50)
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            .wait(50)
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            .wait(50)
+            .get('[data-id="a"]')
+            .trigger("click", { force: true })
+            .wait(2000)
+            .get('[data-panel="a"]')
+            .should("exist")
+            .then(($el: any) => {
+                const height = parseFloat(
+                    getComputedStyle($el[0] as HTMLElement).height
+                )
+                const opacity = parseFloat(
+                    getComputedStyle($el[0] as HTMLElement).opacity
+                )
+                expect(height).to.be.greaterThan(100)
+                expect(opacity).to.equal(1)
+            })
+    })
+})


### PR DESCRIPTION
## Summary

Adds a Cypress regression test for the accordion rapid-click scenario reported in #2674 (motion.section with an explicit \`key\` inside \`AnimatePresence\`, rapidly toggled open/closed).

## Investigation

The original CodeSandbox could not be fetched (CloudFlare-blocked), so the test reconstructs the scenario from the reporter's description and screenshots:

- Multiple accordion items, each with its own \`AnimatePresence\`
- A keyed \`motion.section\` conditionally rendered inside
- \`height: 0\` ↔ \`height: \"auto\"\` enter/exit

The reporter observed visual glitches under rapid clicking and noted that removing the \`key\` from the \`motion.section\` resolved it.

**I could not reproduce the bug against the current codebase.** All three test variants pass (open mid-exit, close mid-enter, 5x rapid toggle) on both React 18 and React 19 without any code changes.

The issue was filed in May 2024, and numerous \`AnimatePresence\` rapid-switching / re-entry fixes have landed since — likely resolving it transitively:

- \`90d8c5364\` Fix AnimatePresence not removing children when exit matches current values
- \`10427ae38\` Fix AnimatePresence stuck when state changes too fast in mode='wait'
- \`6a8d3abb9\` Fix AnimatePresence re-entry: replay enter animation when exit completed
- \`05842be0d\` Fix AnimatePresence wrong animation direction when key re-enters during exit
- \`8798d7017\` Fix AnimatePresence keeping exiting children in DOM during rapid updates with dynamic variants
- \`aa8b46be3\` Fix duplicate exit animation processing in AnimatePresence

The test is included as a forward regression gate covering the specific keyed-child accordion pattern, so any future regression in this area would be caught immediately.

Opening as **draft** because no production code is changed — please confirm whether the bug is indeed considered resolved and the test should land on its own. If it should be closed without merging, that's also fine.

Fixes #2674

## Test plan

- [x] \`yarn build\` passes
- [x] \`yarn test\` passes (776 tests)
- [x] New Cypress spec passes on React 18
- [x] New Cypress spec passes on React 19