### PR TITLE
Update Drag-to-reorder example to use modern MotionValue API (refs #2805)

### DIFF
--- a/dev/react/src/examples/Drag-to-reorder.tsx
+++ b/dev/react/src/examples/Drag-to-reorder.tsx
@@ -1,11 +1,44 @@
 import { useEffect, useState } from "react"
-import { Reorder, useMotionValue, animate } from "framer-motion"
+import {
+    Reorder,
+    useMotionValue,
+    animate,
+    MotionValue,
+} from "framer-motion"
 
 const inactiveShadow = "0px 0px 0px rgba(0,0,0,0.8)"
+const activeShadow = "5px 5px 10px rgba(0,0,0,0.3)"
 
-const Item = ({ item, axis }) => {
-    const y = useMotionValue(0)
+function useRaisedShadow(value: MotionValue<number>) {
     const boxShadow = useMotionValue(inactiveShadow)
+
+    useEffect(() => {
+        let isActive = false
+
+        const unsubscribe = value.on("change", (latest) => {
+            const wasActive = isActive
+            if (latest !== 0) {
+                isActive = true
+                if (isActive !== wasActive) {
+                    animate(boxShadow, activeShadow)
+                }
+            } else {
+                isActive = false
+                if (isActive !== wasActive) {
+                    animate(boxShadow, inactiveShadow)
+                }
+            }
+        })
+
+        return () => unsubscribe()
+    }, [value, boxShadow])
+
+    return boxShadow
+}
+
+const Item = ({ item }) => {
+    const y = useMotionValue(0)
+    const boxShadow = useRaisedShadow(y)
 
     return (
         <Reorder.Item
@@ -22,17 +55,16 @@ const Item = ({ item, axis }) => {
 
 export const App = () => {
     const [items, setItems] = useState(initialItems)
-    const axis = "y"
 
     return (
         <Reorder.Group
             axis="y"
             onReorder={setItems}
-            style={axis === "y" ? verticalList : horizontalList}
+            style={verticalList}
             values={items}
         >
             {items.map((item) => (
-                <Item axis={axis} key={item} item={item} />
+                <Item key={item} item={item} />
             ))}
             <style>{styles}</style>
         </Reorder.Group>
@@ -97,10 +129,6 @@ function ReorderIcon() {
 }
 
 const verticalList = {}
-
-const horizontalList = {
-    display: "flex",
-}
 
 const styles = `body {
   width: 100vw;


### PR DESCRIPTION
## Summary

Refs #2805.

The reported bug is in **external CodeSandbox** examples linked from the docs (see issue), not in this repo's source. Those sandboxes still call `value.onChange(...)`, which now logs a deprecation warning pointing users at `value.on("change", ...)`.

The CodeSandboxes themselves can't be updated from this repo, but the local example at `dev/react/src/examples/Drag-to-reorder.tsx` had `useEffect` and `animate` imported and never used, and declared a `boxShadow` MotionValue that was never animated — the box-shadow-on-drag logic from the original CodeSandbox had been dropped at some point. This PR restores it as a `useRaisedShadow` hook using the modern `value.on("change", ...)` API, so the in-repo example matches the pattern the docs sandboxes should adopt.

## What this PR does
- Adds a `useRaisedShadow(value)` hook to the example, using `value.on("change", ...)` (matches the code replacement suggestion in #2805)
- Wires it into `Item` so the dragged item raises/lowers its shadow
- Drops the unused `axis`/`horizontalList` branches (the example was hardcoded to `axis="y"` anyway)

## What this PR does **not** do
- Update the external CodeSandboxes (`n27v5`, `j9enw`, `uonye`) — those need to be edited via CodeSandbox by a maintainer. The replacement code from #2805 (and now this example) can be pasted in.

Marked draft because the issue isn't fully resolved until the external sandboxes are updated.

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (797 passed, 7 skipped — same as main)
- [ ] Maintainer to update the three CodeSandboxes linked in #2805 to drop the deprecated `onChange` usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)