### PR TITLE
Add regression test for linear motion-value animation (#2826)

### DIFF
--- a/dev/react/src/tests/issue-2826-linear-motion-value.tsx
+++ b/dev/react/src/tests/issue-2826-linear-motion-value.tsx
@@ -1,0 +1,33 @@
+import { animate, motion, useMotionValue } from "framer-motion"
+import { useEffect } from "react"
+
+/**
+ * Reproduces the scenario from issue #2826:
+ *   useMotionValue + animate(motionValue, [0, 1], { ease: "linear",
+ *   type: "keyframes", times: [0, 1] }) wired to motion.div opacity.
+ * The animation should progress linearly across its duration.
+ */
+export const App = () => {
+    const opacity = useMotionValue(0)
+
+    useEffect(() => {
+        animate(opacity, [0, 1], {
+            duration: 10,
+            ease: "linear",
+            type: "keyframes",
+            times: [0, 1],
+        })
+    }, [])
+
+    return (
+        <motion.div
+            id="box"
+            style={{
+                width: 100,
+                height: 100,
+                background: "red",
+                opacity,
+            }}
+        />
+    )
+}

--- a/packages/framer-motion/cypress/integration/issue-2826-linear-motion-value.ts
+++ b/packages/framer-motion/cypress/integration/issue-2826-linear-motion-value.ts
@@ -1,0 +1,35 @@
+describe("issue 2826: animate(motionValue) with ease: 'linear' renders linearly", () => {
+    it("opacity progresses linearly across the duration", () => {
+        const tolerance = 0.1
+
+        cy.visit("?test=issue-2826-linear-motion-value")
+            .wait(2500)
+            .get("#box")
+            .then(([$element]: any) => {
+                const opacity = parseFloat(
+                    getComputedStyle($element).opacity
+                )
+                // 25% through 10s should be ~0.25
+                expect(opacity).to.be.greaterThan(0.25 - tolerance)
+                expect(opacity).to.be.lessThan(0.25 + tolerance)
+            })
+            .wait(2500)
+            .then(([$element]: any) => {
+                const opacity = parseFloat(
+                    getComputedStyle($element).opacity
+                )
+                // 50% through 10s should be ~0.5
+                expect(opacity).to.be.greaterThan(0.5 - tolerance)
+                expect(opacity).to.be.lessThan(0.5 + tolerance)
+            })
+            .wait(2500)
+            .then(([$element]: any) => {
+                const opacity = parseFloat(
+                    getComputedStyle($element).opacity
+                )
+                // 75% through 10s should be ~0.75
+                expect(opacity).to.be.greaterThan(0.75 - tolerance)
+                expect(opacity).to.be.lessThan(0.75 + tolerance)
+            })
+    })
+})


### PR DESCRIPTION
## Summary

Adds a regression test mirroring the exact reproduction from issue #2826:
`useMotionValue(0)` + `animate(value, [0, 1], { ease: "linear", type: "keyframes", times: [0, 1] })` driving `motion.div` opacity. The test asserts the rendered opacity tracks linearly at the 25 %, 50 %, and 75 % marks of a 10 s animation.

## Investigation

The user's repro uses framer-motion 6.2.8 (Feb 2022). On the current `main`, both the JS animation pipeline (`JSAnimation` + the `keyframes` generator) and the rendered DOM opacity progress linearly — I could not reproduce the reported flicker at 50 % in Jest (JSDOM) or in Cypress (Electron Chrome, React 18 and React 19). The likely culprit was fixed incidentally during the rewrite of the animation pipeline between v6 and v12.

Rather than landing speculative code changes for a bug I cannot trigger, this PR locks in the desired behavior so a regression to the original buggy state would fail CI.

- Test page: `dev/react/src/tests/issue-2826-linear-motion-value.tsx`
- Cypress spec: `packages/framer-motion/cypress/integration/issue-2826-linear-motion-value.ts`

Fixes #2826

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn test` — 797 tests pass
- [x] Cypress spec passes on React 18 (Vite dev server, headed Electron)
- [x] Cypress spec passes on React 19 (Vite dev server, headed Electron)