### PR TITLE
Fix drag being blocked by variant transform string (#2807)

### DIFF
--- a/dev/react/src/tests/drag-variant-transform.tsx
+++ b/dev/react/src/tests/drag-variant-transform.tsx
@@ -1,0 +1,48 @@
+import { motion, useDragControls, Variants } from "framer-motion"
+
+const variants: Variants = {
+    none: (custom?: string) => ({
+        width: "fit-content",
+        height: "fit-content",
+        transform: custom || undefined,
+    }),
+}
+
+// Regression test for #2807: a variant that sets a literal `transform` string
+// should not prevent drag from moving the element.
+export const App = () => {
+    const dragControls = useDragControls()
+
+    return (
+        <div style={{ height: 800, padding: 100 }}>
+            <button
+                data-testid="handle"
+                onPointerDown={(e) => dragControls.start(e)}
+                style={{
+                    display: "block",
+                    width: 100,
+                    height: 20,
+                    background: "blue",
+                    marginBottom: 10,
+                }}
+            />
+            <motion.div
+                data-testid="draggable"
+                custom="translate(50px, 60px)"
+                initial="none"
+                animate="none"
+                variants={variants}
+                drag
+                dragListener={false}
+                dragControls={dragControls}
+                dragMomentum={false}
+                style={{
+                    background: "red",
+                    padding: 30,
+                }}
+            >
+                window
+            </motion.div>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/drag-variant-transform.ts
+++ b/packages/framer-motion/cypress/integration/drag-variant-transform.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression test for #2807: a variant that sets a literal `transform` string
+ * should not prevent drag from moving the element.
+ */
+describe("Drag with variant-set transform", () => {
+    it("Drags the element even when a variant sets a literal transform string", () => {
+        cy.visit("?test=drag-variant-transform")
+
+        // The variant applies `transform: "translate(50px, 60px)"` so the
+        // initial bounding rect reflects that translation (padding 100 + 50).
+        cy.get("[data-testid='draggable']")
+            .wait(200)
+            .then(($el: any) => {
+                expect(
+                    $el[0].getBoundingClientRect().left,
+                    "initial transform from variant is applied"
+                ).to.equal(150)
+            })
+
+        cy.get("[data-testid='handle']")
+            .trigger("pointerdown", 5, 5)
+            .trigger("pointermove", 10, 10)
+            .wait(50)
+            .trigger("pointermove", 200, 250, { force: true })
+            .wait(50)
+            .trigger("pointerup", { force: true })
+
+        cy.get("[data-testid='draggable']").should(($el: any) => {
+            const { left, top } = $el[0].getBoundingClientRect()
+            // Drag moved the pointer by ~195/245 px. The element should have
+            // moved by the same amount from its initial position.
+            expect(left, "left after drag").to.be.greaterThan(250)
+            expect(top, "top after drag").to.be.greaterThan(250)
+        })
+    })
+})

--- a/packages/framer-motion/src/render/html/utils/__tests__/build-styles.test.ts
+++ b/packages/framer-motion/src/render/html/utils/__tests__/build-styles.test.ts
@@ -110,6 +110,16 @@ describe("buildHTMLStyles", () => {
             transform: "translateY(2) translateX(1px)",
         })
     })
+
+    test("Individual transform props take precedence over transform string", () => {
+        const latest = { x: 50, transform: "translateX(100px)" }
+        const style = {}
+        build(latest, { style })
+
+        expect(style).toEqual({
+            transform: "translateX(50px)",
+        })
+    })
 })
 
 interface BuildProps {

--- a/packages/motion-dom/src/render/html/utils/build-styles.ts
+++ b/packages/motion-dom/src/render/html/utils/build-styles.ts
@@ -49,14 +49,23 @@ export function buildHTMLStyles(
         }
     }
 
-    if (!latestValues.transform) {
+    /**
+     * If x or y motion values are present they take precedence over any
+     * `transform` string in latestValues. This allows drag (and other gestures
+     * that drive x/y) to keep working when a variant or style sets a literal
+     * `transform` string. See #2807.
+     */
+    const hasTranslate =
+        latestValues.x !== undefined || latestValues.y !== undefined
+
+    if (!latestValues.transform || hasTranslate) {
         if (hasTransform || transformTemplate) {
             style.transform = buildTransform(
                 latestValues,
                 state.transform,
                 transformTemplate
             )
-        } else if (style.transform) {
+        } else if (!latestValues.transform && style.transform) {
             /**
              * If we have previously created a transform but currently don't have any,
              * reset transform style to none.


### PR DESCRIPTION
## Summary

- `buildHTMLStyles` previously preferred a literal `transform` string in `latestValues` over the computed transform from individual props. When a variant set `transform: "..."` and drag (or another gesture) was driving `x`/`y` motion values, the gesture's translations were silently dropped.
- This change makes `buildTransform` win whenever `x` or `y` are present in `latestValues`, so a variant-set transform string no longer blocks drag.

## Bug

Reported in #2807. Repro from the issue:

```tsx
const variants: Variants = {
  none: (custom) => ({
    width: "fit-content",
    height: "fit-content",
    transform: custom || undefined,
  }),
}

<motion.div
  custom={positionBackup.current}
  initial="none"
  animate="none"
  variants={variants}
  drag
  dragControls={dragControls}
  dragListener={false}
/>
```

The `none` variant sets `transform` to a literal string. When drag updated `x`/`y` motion values, `latestValues.transform` was still truthy, so the old check (`if (!latestValues.transform)`) skipped `buildTransform` entirely and `style.transform` stayed at the variant string — drag did nothing.

## Fix

`packages/motion-dom/src/render/html/utils/build-styles.ts`: extend the gate so we still run `buildTransform` when `x` or `y` is in `latestValues`. The previous behaviour is preserved when neither translate axis is set, so a `useMotionTemplate`-based transform string with non-translate motion values (e.g. `scale`) still wins — the existing "Prioritises transform over independent transforms" test continues to pass.

## Test plan

- [x] New unit test in `build-styles.test.ts` asserts that `{ x: 50, transform: "translateX(100px)" }` resolves to `transform: "translateX(50px)"`. Fails without the fix.
- [x] New Cypress test `drag-variant-transform.ts` reproduces the issue's scenario (`dragControls` + `dragListener={false}` + variant `transform` string) and checks the element moves. Fails on `main` (`left=150` — variant transform wins), passes with the fix.
- [x] Cypress passes on React 18 and React 19.
- [x] Full `yarn test` (798 tests) passes.

Fixes #2807

🤖 Generated with [Claude Code](https://claude.com/claude-code)