### PR TITLE
fix: prefer active grouped animation state

### DIFF
--- a/packages/motion-dom/src/animation/GroupAnimation.ts
+++ b/packages/motion-dom/src/animation/GroupAnimation.ts
@@ -25,11 +25,12 @@ export class GroupAnimation implements AnimationPlaybackControls {
         )
     }
 
-    /**
-     * TODO: Filter out cancelled or stopped animations before returning
-     */
     private getAll(propName: PropNames) {
-        return this.animations[0][propName] as any
+        const activeAnimation = this.animations.find((animation) => {
+            return animation.state !== "idle" && animation.state !== "finished"
+        })
+
+        return (activeAnimation || this.animations[0])[propName] as any
     }
 
     private setAll(propName: PropNames, newValue: any) {

--- a/packages/motion-dom/src/animation/__tests__/GroupAnimation.test.ts
+++ b/packages/motion-dom/src/animation/__tests__/GroupAnimation.test.ts
@@ -214,6 +214,50 @@ describe("GroupAnimation", () => {
         expect(controls.startTime).toEqual(2)
     })
 
+    test("Gets active properties when first animation is finished", () => {
+        const a = createTestAnimationControls({
+            speed: 0,
+            time: 1,
+            startTime: 0,
+            state: "finished",
+        })
+        const b = createTestAnimationControls({
+            speed: 3,
+            time: 2,
+            startTime: 10,
+            state: "running",
+        })
+
+        const controls = new GroupAnimation([a, b])
+
+        expect(controls.state).toEqual("running")
+        expect(controls.speed).toEqual(3)
+        expect(controls.time).toEqual(2)
+        expect(controls.startTime).toEqual(10)
+    })
+
+    test("Falls back to first animation when all animations are finished", () => {
+        const a = createTestAnimationControls({
+            speed: 1,
+            time: 1,
+            startTime: 0,
+            state: "finished",
+        })
+        const b = createTestAnimationControls({
+            speed: 2,
+            time: 2,
+            startTime: 10,
+            state: "finished",
+        })
+
+        const controls = new GroupAnimation([a, b])
+
+        expect(controls.state).toEqual("finished")
+        expect(controls.speed).toEqual(1)
+        expect(controls.time).toEqual(1)
+        expect(controls.startTime).toEqual(0)
+    })
+
     test("Gets max duration", async () => {
         const a = createTestAnimationControls({
             duration: 3,


### PR DESCRIPTION
## Summary

`GroupAnimation` read shared getters like `state`, `speed`, `time`, and `startTime` from the first child animation, even when that animation had already finished or become idle. This meant a grouped animation could report stale values while a later child animation was still running.

This updates the grouped getter path to prefer the first active child animation, falling back to the first animation only when every child is inactive. The regression tests cover both the active-child case and the all-finished fallback.

## Validation

- `node .\node_modules\jest\bin\jest.js --config packages/motion-dom/jest.config.json --runInBand --runTestsByPath packages/motion-dom/src/animation/__tests__/GroupAnimation.test.ts`
- `.\node_modules\.bin\prettier.cmd --check packages/motion-dom/src/animation/GroupAnimation.ts packages/motion-dom/src/animation/__tests__/GroupAnimation.test.ts`
- `.\node_modules\.bin\eslint.cmd packages/motion-dom/src/animation/GroupAnimation.ts packages/motion-dom/src/animation/__tests__/GroupAnimation.test.ts` (clean exit; existing warning-level return-type messages in this file)
- `node .\node_modules\typescript\bin\tsc -p packages/motion-utils`
- `node ..\..\node_modules\rollup\dist\bin\rollup -c rollup.config.mjs` from `packages/motion-utils`
- `node .\node_modules\jest\bin\jest.js --config packages/motion-dom/jest.config.json --maxWorkers=2`