### PR TITLE
fix: resolve wildcard final keyframes in resolver

### DIFF
--- a/packages/motion-dom/src/animation/keyframes/KeyframesResolver.ts
+++ b/packages/motion-dom/src/animation/keyframes/KeyframesResolver.ts
@@ -165,22 +165,31 @@ export class KeyframeResolver<T extends AnyResolvedKeyframe = any> {
         if (unresolvedKeyframes[0] === null) {
             const currentValue = motionValue?.get()
 
-            // TODO: This doesn't work if the final keyframe is a wildcard
             const finalKeyframe =
                 unresolvedKeyframes[unresolvedKeyframes.length - 1]
+            const finalKeyframeOrDefault =
+                finalKeyframe === null && this.finalKeyframe !== undefined
+                    ? this.finalKeyframe
+                    : finalKeyframe
 
             if (currentValue !== undefined) {
                 unresolvedKeyframes[0] = currentValue
             } else if (element && name) {
-                const valueAsRead = element.readValue(name, finalKeyframe)
+                const valueAsRead = element.readValue(
+                    name,
+                    finalKeyframeOrDefault
+                )
 
                 if (valueAsRead !== undefined && valueAsRead !== null) {
                     unresolvedKeyframes[0] = valueAsRead
                 }
             }
 
-            if (unresolvedKeyframes[0] === undefined) {
-                unresolvedKeyframes[0] = finalKeyframe
+            if (
+                unresolvedKeyframes[0] === null ||
+                unresolvedKeyframes[0] === undefined
+            ) {
+                unresolvedKeyframes[0] = finalKeyframeOrDefault
             }
 
             if (motionValue && currentValue === undefined) {

--- a/packages/motion-dom/src/animation/keyframes/__tests__/keyframes-resolver.test.ts
+++ b/packages/motion-dom/src/animation/keyframes/__tests__/keyframes-resolver.test.ts
@@ -1,0 +1,22 @@
+import { KeyframeResolver } from "../KeyframesResolver"
+
+describe("KeyframeResolver", () => {
+    test("uses the resolved final keyframe when start keyframe is a wildcard", () => {
+        const readValue = jest.fn(() => undefined)
+
+        const resolver = new KeyframeResolver<number>(
+            [null as any, null as any],
+            (resolvedKeyframes) => {
+                expect(resolvedKeyframes).toEqual([300, 300])
+            },
+            "x",
+            undefined,
+            { readValue } as any
+        )
+
+        resolver.finalKeyframe = 300
+        resolver.scheduleResolve()
+
+        expect(readValue).toHaveBeenCalledWith("x", 300)
+    })
+})


### PR DESCRIPTION
### Summary

When the first and final keyframes are both wildcards, `KeyframesResolver` read the initial value with `null` as the fallback and could leave the first keyframe unresolved. This path has an existing resolver TODO and can affect inertia animations that provide a resolved `finalKeyframe` separately.

This PR uses `this.finalKeyframe` as the fallback when the final unresolved keyframe is a wildcard, and treats a still-null first keyframe as unresolved before wildcard filling runs.

Refs #1747.

### Validation

- `npx --no-install jest --config packages/motion-dom/jest.config.json --runInBand packages/motion-dom/src/animation/keyframes/__tests__/keyframes-resolver.test.ts`
- `npx --no-install jest --config packages/motion-dom/jest.config.json --runInBand`
- `npx --no-install tsc -p packages/motion-dom/tsconfig.json --noEmit`
- `npx --no-install prettier --check packages/motion-dom/src/animation/keyframes/KeyframesResolver.ts packages/motion-dom/src/animation/keyframes/__tests__/keyframes-resolver.test.ts`
- `npx --no-install eslint packages/motion-dom/src/animation/keyframes/KeyframesResolver.ts packages/motion-dom/src/animation/keyframes/__tests__/keyframes-resolver.test.ts` (warning-only existing explicit return type messages in `KeyframesResolver.ts`)