### PR TITLE
fix(gestures): end drag/press from capture phase so child stopPropagation can't trap the gesture

### DIFF
--- a/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
@@ -7,7 +7,7 @@ import {
     MotionValue,
     useWillChange,
 } from "../../../"
-import { pointerDown, pointerMove, render } from "../../../jest.setup"
+import { pointerDown, pointerMove, pointerUp, render } from "../../../jest.setup"
 import { WillChangeMotionValue } from "../../../value/use-will-change/WillChangeMotionValue"
 import { nextFrame } from "../../__tests__/utils"
 import { deferred, drag, dragFrame, MockDrag, Point, sleep } from "./utils"
@@ -137,6 +137,31 @@ describe("dragging", () => {
 
         const pointer = await drag(container.firstChild).to(100, 100)
         pointer.end()
+
+        await nextFrame()
+
+        expect(onDragEnd).toBeCalledTimes(1)
+    })
+
+    test("dragEnd fires when a child stops pointerup propagation (#2794)", async () => {
+        const onDragEnd = jest.fn()
+        const Component = () => (
+            <MockDrag>
+                <motion.div drag="y" onDragEnd={onDragEnd}>
+                    <div
+                        data-testid="child"
+                        onPointerUp={(event) => event.stopPropagation()}
+                    />
+                </motion.div>
+            </MockDrag>
+        )
+
+        const { container, getByTestId, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        await drag(container.firstChild).to(0, 100)
+
+        pointerUp(getByTestId("child"))
 
         await nextFrame()
 

--- a/packages/framer-motion/src/gestures/pan/PanSession.ts
+++ b/packages/framer-motion/src/gestures/pan/PanSession.ts
@@ -148,21 +148,28 @@ export class PanSession {
         onSessionStart &&
             onSessionStart(event, getPanInfo(initialInfo, this.history))
 
+        // Listen in the capture phase so a descendant calling
+        // stopPropagation() (e.g. in its own pointerup handler) can't
+        // prevent the gesture from ending. See #2794.
+        const eventOptions = { passive: true, capture: true }
         this.removeListeners = pipe(
             addPointerEvent(
                 this.contextWindow,
                 "pointermove",
-                this.handlePointerMove
+                this.handlePointerMove,
+                eventOptions
             ),
             addPointerEvent(
                 this.contextWindow,
                 "pointerup",
-                this.handlePointerUp
+                this.handlePointerUp,
+                eventOptions
             ),
             addPointerEvent(
                 this.contextWindow,
                 "pointercancel",
-                this.handlePointerUp
+                this.handlePointerUp,
+                eventOptions
             )
         )
 

--- a/packages/motion-dom/src/events/add-dom-event.ts
+++ b/packages/motion-dom/src/events/add-dom-event.ts
@@ -6,5 +6,5 @@ export function addDomEvent(
 ) {
     target.addEventListener(eventName, handler, options)
 
-    return () => target.removeEventListener(eventName, handler)
+    return () => target.removeEventListener(eventName, handler, options)
 }

--- a/packages/motion-dom/src/gestures/press/index.ts
+++ b/packages/motion-dom/src/gestures/press/index.ts
@@ -68,9 +68,25 @@ export function press(
 
         const onPressEnd = onPressStart(target, startEvent)
 
+        /**
+         * End listeners run in the capture phase so a descendant calling
+         * stopPropagation() in its own pointerup handler can't prevent the
+         * press gesture from ending. This also keeps the gesture-end
+         * ordering consistent with the drag gesture. See #2794.
+         */
+        const endEventOptions = { ...eventOptions, capture: true }
+
         const onPointerEnd = (endEvent: PointerEvent, success: boolean) => {
-            window.removeEventListener("pointerup", onPointerUp)
-            window.removeEventListener("pointercancel", onPointerCancel)
+            window.removeEventListener(
+                "pointerup",
+                onPointerUp,
+                endEventOptions
+            )
+            window.removeEventListener(
+                "pointercancel",
+                onPointerCancel,
+                endEventOptions
+            )
 
             if (isPressing.has(target)) {
                 isPressing.delete(target)
@@ -99,8 +115,12 @@ export function press(
             onPointerEnd(cancelEvent, false)
         }
 
-        window.addEventListener("pointerup", onPointerUp, eventOptions)
-        window.addEventListener("pointercancel", onPointerCancel, eventOptions)
+        window.addEventListener("pointerup", onPointerUp, endEventOptions)
+        window.addEventListener(
+            "pointercancel",
+            onPointerCancel,
+            endEventOptions
+        )
     }
 
     targets.forEach((target: EventTarget) => {


### PR DESCRIPTION
## Summary

Fixes #2794.

When a child of a `drag` element calls `event.stopPropagation()` inside its own `onPointerUp` handler, the drag gesture never ended — the element kept following the cursor until the next pointer interaction.

### Cause

`PanSession` attaches its `pointermove` / `pointerup` / `pointercancel` listeners to `window` in the **bubble** phase. A descendant calling `stopPropagation()` on `pointerup` stops the event before it reaches `window`, so `handlePointerUp` never runs, the session is never torn down, and `pointermove` keeps dragging the element.

### Fix

- **`PanSession`**: attach the gesture pointer listeners in the **capture** phase, so descendant `stopPropagation()` can no longer prevent the gesture from ending.
- **`addDomEvent`**: pass the listener `options` to `removeEventListener`, otherwise capture-phase listeners are never removed (capture flag must match) and would leak.
- **`press` gesture**: move its end (`pointerup` / `pointercancel`) listeners to the capture phase as well. This keeps the existing "a drag suppresses the tap" ordering intact (press still observes `isDragActive()` before the drag releases its lock) and makes the press/tap gesture robust to the same `stopPropagation` problem (the issue's repro literally stops propagation on `pointerup`).

The fix is internal only — no public API changes.

## Test plan

- [x] Added a regression test in the drag suite: a `drag` element whose child calls `stopPropagation()` in `onPointerUp` — asserts `onDragEnd` fires. Verified it **fails** against the unfixed code and **passes** with the fix.
- [x] `yarn build` succeeds.
- [x] `yarn test` — full suite green (798 passed, 7 pre-existing skips).
- [x] Gesture suites (drag, pan, press, tap, hover) all pass, confirming no regression to the drag-suppresses-tap behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)