### PR TITLE
[audit] motion-dom/stats: dedupe summarise calls, inline helpers

### DIFF
--- a/packages/motion-dom/src/stats/index.ts
+++ b/packages/motion-dom/src/stats/index.ts
@@ -5,11 +5,7 @@ import { StatsSummary, Summary } from "./types"
 
 function record() {
     const { value } = statsBuffer
-
-    if (value === null) {
-        cancelFrame(record)
-        return
-    }
+    if (!value) return
 
     value.frameloop.rate.push(frameData.delta)
     value.animations.mainThread.push(activeAnimations.mainThread)
@@ -17,30 +13,24 @@ function record() {
     value.animations.layout.push(activeAnimations.layout)
 }
 
-function mean(values: number[]) {
-    return values.reduce((acc, value) => acc + value, 0) / values.length
-}
-
-function summarise(
-    values: number[],
-    calcAverage: (allValues: number[]) => number = mean
-): Summary {
-    if (values.length === 0) {
-        return {
-            min: 0,
-            max: 0,
-            avg: 0,
-        }
-    }
+function summarise(values: number[]): Summary {
+    const { length } = values
+    if (length === 0) return { min: 0, max: 0, avg: 0 }
 
     return {
         min: Math.min(...values),
         max: Math.max(...values),
-        avg: calcAverage(values),
+        avg: values.reduce((a, v) => a + v, 0) / length,
     }
 }
 
-const msToFps = (ms: number) => Math.round(1000 / ms)
+function summariseAll<T extends string>(
+    obj: Record<T, number[]>
+): Record<T, Summary> {
+    const result = {} as Record<T, Summary>
+    for (const key in obj) result[key] = summarise(obj[key])
+    return result
+}
 
 function clearStatsBuffer() {
     statsBuffer.value = null
@@ -58,42 +48,19 @@ function reportStats(): StatsSummary {
     cancelFrame(record)
 
     const summary = {
-        frameloop: {
-            setup: summarise(value.frameloop.setup),
-            rate: summarise(value.frameloop.rate),
-            read: summarise(value.frameloop.read),
-            resolveKeyframes: summarise(value.frameloop.resolveKeyframes),
-            preUpdate: summarise(value.frameloop.preUpdate),
-            update: summarise(value.frameloop.update),
-            preRender: summarise(value.frameloop.preRender),
-            render: summarise(value.frameloop.render),
-            postRender: summarise(value.frameloop.postRender),
-        },
-        animations: {
-            mainThread: summarise(value.animations.mainThread),
-            waapi: summarise(value.animations.waapi),
-            layout: summarise(value.animations.layout),
-        },
-        layoutProjection: {
-            nodes: summarise(value.layoutProjection.nodes),
-            calculatedTargetDeltas: summarise(
-                value.layoutProjection.calculatedTargetDeltas
-            ),
-            calculatedProjections: summarise(
-                value.layoutProjection.calculatedProjections
-            ),
-        },
+        frameloop: summariseAll(value.frameloop),
+        animations: summariseAll(value.animations),
+        layoutProjection: summariseAll(value.layoutProjection),
     }
 
     /**
-     * Convert the rate to FPS
+     * Convert the rate to FPS. Min/max are swapped because the conversion inverts them.
      */
     const { rate } = summary.frameloop
-    rate.min = msToFps(rate.min)
-    rate.max = msToFps(rate.max)
-    rate.avg = msToFps(rate.avg)
-    // Swap these as the min and max are inverted when converted to FPS
-    ;[rate.min, rate.max] = [rate.max, rate.min]
+    rate.avg = Math.round(1000 / rate.avg)
+    const max = Math.round(1000 / rate.min)
+    rate.min = Math.round(1000 / rate.max)
+    rate.max = max
 
     return summary
 }


### PR DESCRIPTION
## Directory

`packages/motion-dom/src/stats/` — debug-mode runtime stats collection.
Exports `recordStats` (called from `framer-motion/src/debug.ts` and
`projection.ts`) plus the internal `statsBuffer` and `activeAnimations`
that hot-path code (JSAnimation, WAAPI start, projection node)
increments/decrements and conditionally reads from. `recordStats` is the
only public entry: it allocates buffer arrays, schedules `record()` on
every `postRender` frame, and returns a `reportStats()` closure that
summarises the buffer into a `StatsSummary`.

Both lenses applied.

## Performance

No changes. The per-frame work inside `record()` is gated on
`statsBuffer.value`, so it's only active during an explicit
`recordStats()` profiling session. All hot-path call sites elsewhere
already short-circuit on `if (statsBuffer.value)` / `if (statsBuffer.addProjectionMetrics)`
before touching the buffer, so there is no idle-cost to trim. The
`reportStats()` work (`Math.min(...values)` / `Math.max(...values)` /
`reduce`) runs once when the user ends a session — not a hot path.

## Filesize

Measured per-file gzipped deltas after `yarn build`:

| Output | Before | After | Δ |
|---|---:|---:|---:|
| `motion-dom/dist/motion-dom.js` | 38921 | 38799 | **−122** |
| `motion-dom/dist/motion-dom.dev.js` | 90813 | 90655 | **−158** |
| `motion-dom/dist/cjs/index.js` | 89109 | 88989 | **−120** |
| `motion-dom/dist/es/stats/index.mjs` | 997 | 910 | **−87** |
| `framer-motion/dist/framer-motion.js` | 60694 | 60568 | **−126** |
| `framer-motion/dist/dom.js` | 44678 | 44568 | **−110** |
| `framer-motion/dist/dom-mini.js` | 4979 | 4979 | 0 (no stats) |
| `motion-dom/dist/es/index.mjs` | 3094 | 3094 | 0 (barrel only) |

User-facing bundles drop ~110–126 gzipped bytes each.

### Changes (all in `reportStats` / `summarise`):

1. **Collapse 15× `summarise(value.X.Y)` into a generic `summariseAll`
   helper** that iterates each sub-object's keys. The summary object
   shrinks from three nested literals (~700 chars pre-min) to three
   helper calls. This is the bulk of the win.
2. **Inline single-use `mean()`** — the `calcAverage` default
   parameter was never overridden by any caller. Replaced with an
   inline `reduce` inside `summarise`.
3. **Inline single-use `msToFps()`** — three call sites become
   `Math.round(1000 / x)` directly; the explicit array-destructuring
   swap becomes a single temp, which compresses slightly better.
4. **Drop the defensive `cancelFrame(record)` inside `record()`** —
   `reportStats()` already calls `cancelFrame(record)` before clearing
   the buffer, so the null branch was unreachable. Replaced with a
   simple `if (!value) return`.

No public API changed; `recordStats` / `statsBuffer` / `activeAnimations`
signatures are identical.

## Verification

- `yarn build` clean.
- `yarn test` — all stats tests pass (3/3 in `motion-dom/src/stats/__tests__/index.test.ts`).
  One unrelated AnimatePresence test was flaky on the first run and
  passed on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)