### PR TITLE
Fix spurious React 18.3 `ref` warning in AnimatePresence non-popLayout mode

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -87,10 +87,16 @@ export function PopChild({ children, isPresent, anchorX, anchorY, root, pop }: P
     /**
      * In React 19, refs are passed via props.ref instead of element.ref.
      * We check props.ref first (React 19) and fall back to element.ref (React 18).
+     *
+     * The composed ref is only used when popping the child out (pop !== false),
+     * so we avoid reading children.props.ref otherwise. In React 18.3 that read
+     * triggers a spurious "`ref` is not a prop" warning getter (#3745).
      */
     const childRef =
-        (children.props as { ref?: React.Ref<HTMLElement> })?.ref ??
-        (children as unknown as { ref?: React.Ref<HTMLElement> })?.ref
+        pop !== false
+            ? ((children.props as { ref?: React.Ref<HTMLElement> })?.ref ??
+              (children as unknown as { ref?: React.Ref<HTMLElement> })?.ref)
+            : undefined
     const composedRef = useComposedRefs(ref, childRef)
 
     /**

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/pop-child-ref.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/pop-child-ref.test.tsx
@@ -1,0 +1,46 @@
+import { useRef } from "react"
+import { AnimatePresence, motion } from "../../.."
+import { render } from "../../../jest.setup"
+
+/**
+ * Regression test for #3745.
+ *
+ * In React 18.3, creating an element with a `ref` prop installs a warning
+ * getter on `element.props.ref`. `PopChild` read `children.props.ref`
+ * unconditionally, which fired the "`ref` is not a prop" warning even when not
+ * in `popLayout` mode — where the composed ref is never used.
+ *
+ * This lives in its own test file so React's (module-level) "warned once"
+ * flag starts fresh: other AnimatePresence tests render ref'd children and
+ * would otherwise trip the warning before this test runs.
+ */
+describe("AnimatePresence PopChild ref access", () => {
+    test("does not read children.props.ref in non-popLayout mode", () => {
+        const consoleError = jest
+            .spyOn(console, "error")
+            .mockImplementation(() => {})
+
+        const Component = ({ isVisible }: { isVisible: boolean }) => {
+            const ref = useRef<HTMLDivElement>(null)
+            return (
+                <AnimatePresence>
+                    {isVisible && (
+                        <motion.div key="content" ref={ref} exit={{ opacity: 0 }}>
+                            Hello
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            )
+        }
+
+        render(<Component isVisible />)
+
+        const refWarning = consoleError.mock.calls.find((call) =>
+            call.some((arg) => String(arg).includes("`ref` is not a prop"))
+        )
+
+        consoleError.mockRestore()
+
+        expect(refWarning).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Bug

`AnimatePresence` in any mode other than `popLayout` (i.e. the default `sync` and `wait`) emits a React warning when its child has a `ref`:

```
Warning: [object Object]: `ref` is not a prop. Trying to access it will result in
`undefined` being returned. ...
```

Minimal repro:

```tsx
const ref = useRef(null)

<AnimatePresence>
  {isVisible && (
    <motion.div key="content" ref={ref} exit={{ opacity: 0 }}>
      Hello
    </motion.div>
  )}
</AnimatePresence>
```

## Cause

`PopChild` read `children.props?.ref` unconditionally on every render:

```ts
const childRef =
    (children.props as { ref?: React.Ref<HTMLElement> })?.ref ??
    (children as unknown as { ref?: React.Ref<HTMLElement> })?.ref
```

In React 18.3, creating an element with a `ref` prop installs a warning getter on `element.props.ref` (`defineRefPropWarningGetter`). Any access to that getter fires the warning. The composed ref is only ever *used* in the `pop !== false` branch (`React.cloneElement(children, { ref: composedRef })`), so in non-popLayout mode the read is pointless yet still trips the warning.

The `[object Object]` display name appears because `motion.*` components are `forwardRef` objects (not functions), so React's element validator stringifies the raw object as the display name.

This is distinct from the earlier React 19 `popLayout` ref fixes (v12.23.16, v12.24.5) — it affects **non-popLayout** mode under **React 18.3**.

## Fix

Only read `children.props.ref` when the ref is actually used (`pop !== false`):

```ts
const childRef =
    pop !== false
        ? ((children.props as { ref?: React.Ref<HTMLElement> })?.ref ??
          (children as unknown as { ref?: React.Ref<HTMLElement> })?.ref)
        : undefined
```

`popLayout` behaviour is unchanged — the ref is still read and composed when popping.

## Test

Added `pop-child-ref.test.tsx`, which renders an `AnimatePresence` (default mode) around a ref'd `motion.div` and asserts no `` `ref` is not a prop `` warning is logged. It lives in its own file so React's module-level "warned once" flag starts fresh.

- Fails on `main` for the right reason (warning fired from `PopChild` → `PresenceChild` → `AnimatePresence`).
- Passes with the fix.
- Full `framer-motion` client suite passes (776 tests); all `AnimatePresence`/`PopChild`/`use-presence` suites pass.

Fixes #3745

🤖 Generated with [Claude Code](https://claude.com/claude-code)