### PR TITLE
Fix jumpy scroll-linked animations during native smooth scrolling

### DIFF
--- a/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
+++ b/packages/framer-motion/src/render/dom/scroll/__tests__/index.test.ts
@@ -69,6 +69,18 @@ async function fireScroll(distance: number = 0) {
     return nextFrame()
 }
 
+/**
+ * Advance the frame loop without dispatching a `scroll` event. This emulates a
+ * frame painted during native smooth scrolling where the compositor has moved
+ * the scroll position but the matching `scroll` event hasn't been delivered to
+ * JS yet.
+ */
+async function nextFrameWithoutScrollEvent() {
+    return new Promise<void>((resolve) => {
+        frame.postRender(() => resolve())
+    })
+}
+
 describe("scrollInfo", () => {
     test("Fires onScroll on creation.", async () => {
         const onScroll = jest.fn()
@@ -84,6 +96,38 @@ describe("scrollInfo", () => {
                 resolve()
             })
         })
+    })
+
+    test("Keeps scroll progress in sync on the frame loop without a scroll event (#2716).", async () => {
+        let latest: ScrollInfo
+
+        const stopScroll = scrollInfo((info) => {
+            latest = info
+        })
+
+        setWindowHeight(1000)
+        setDocumentHeight(3000)
+
+        // Establish a baseline via a regular scroll event.
+        await fireScroll(0)
+        expect(latest!.y.current).toEqual(0)
+
+        // Let the frame loop settle so any pending measure has run.
+        await nextFrameWithoutScrollEvent()
+        await nextFrameWithoutScrollEvent()
+
+        // Native smooth scrolling (e.g. mouse wheel) advances the scroll
+        // position on the compositor, but the matching `scroll` event can be
+        // coalesced or delivered a frame late. Motion must still pick up the new
+        // position on the frame loop, otherwise the frame renders with a stale
+        // progress — the jumpy scrolling reported in #2716.
+        setScrollTop(500)
+        await nextFrameWithoutScrollEvent()
+
+        expect(latest!.y.current).toEqual(500)
+        expect(latest!.y.progress).toEqual(0.25)
+
+        stopScroll()
     })
 
     test("Fires onScroll on scroll.", async () => {

--- a/packages/framer-motion/src/render/dom/scroll/track.ts
+++ b/packages/framer-motion/src/render/dom/scroll/track.ts
@@ -9,6 +9,13 @@ const resizeListeners = new WeakMap<Element, VoidFunction>()
 const onScrollHandlers = new WeakMap<Element, Set<OnScrollHandler>>()
 const scrollSize = new WeakMap<Element, { width: number; height: number }>()
 const dimensionCheckProcesses = new WeakMap<Element, Process>()
+const measureProcesses = new WeakMap<Element, Process>()
+
+/**
+ * Number of frames to keep reading the scroll position after it last changed
+ * before stopping, allowing the frameloop to sleep once scrolling settles.
+ */
+const maxSettleFrames = 10
 
 export type ScrollTargets = Array<HTMLElement>
 
@@ -67,9 +74,41 @@ export function scrollInfo(
             }
         }
 
-        const listener = () => frame.read(measureAll)
+        /**
+         * Read the scroll position on every frame while the container is
+         * scrolling, rather than only when a `scroll` event fires. Native smooth
+         * scrolling (mouse wheel, trackpad momentum) advances the scroll offset
+         * on the compositor and can deliver `scroll` events coalesced or a frame
+         * late, so measuring purely on the event leaves some frames rendering a
+         * stale scroll progress — the "jumpy" scrolling reported in #2716. Once
+         * the position stops changing the loop is cancelled so the frameloop can
+         * sleep again.
+         */
+        let settleFrames = 0
+        let prevTop = -1
+        let prevLeft = -1
+        const measureLoop = () => {
+            const top = container.scrollTop
+            const left = container.scrollLeft
+
+            if (top !== prevTop || left !== prevLeft) {
+                settleFrames = 0
+                prevTop = top
+                prevLeft = left
+            }
+
+            measureAll()
+
+            if (++settleFrames > maxSettleFrames) cancelFrame(measureLoop)
+        }
+
+        const listener = () => {
+            settleFrames = 0
+            frame.read(measureLoop, true)
+        }
 
         scrollListeners.set(container, listener)
+        measureProcesses.set(container, measureLoop)
 
         const target = getEventTarget(container)
         window.addEventListener("resize", listener)
@@ -141,6 +180,13 @@ export function scrollInfo(
             )
             resizeListeners.get(container)?.()
             window.removeEventListener("resize", scrollListener)
+        }
+
+        // Stop the per-frame scroll measurement loop
+        const measureProcess = measureProcesses.get(container)
+        if (measureProcess) {
+            cancelFrame(measureProcess)
+            measureProcesses.delete(container)
         }
 
         // Clean up scroll dimension checking


### PR DESCRIPTION
## Bug

When an animation is driven by scroll progress (`useScroll` + `useTransform`), scrolling with a **mouse wheel** is intermittently jumpy, while dragging the **scrollbar** is smooth. Reported on Chrome / Windows 11.

Reproduction (from the issue): a tall container with a box whose `y` tracks `scrollYProgress`, so it should stay pinned as you scroll. With the wheel, it visibly jumps now and then.

```tsx
const { scrollYProgress } = useScroll({ target: ref, offset: ['start start', 'end center'] })
const y = useTransform(() => (rootHeight - targetHeight) * scrollYProgress.get())
```

## Cause

Motion measured the scroll position **only in response to `scroll` events** (`track.ts` attached a `scroll` listener that scheduled a one-off `frame.read(measureAll)`).

Native smooth scrolling — mouse wheel and trackpad momentum — advances the scroll offset on the **compositor thread** and delivers `scroll` events to the main thread **coalesced or a frame late** relative to the position that is actually being painted. Dragging the scrollbar scrolls synchronously on the main thread, so events line up with frames and there's no jump.

Because measurement was event-driven, any painted frame whose scroll change wasn't accompanied by a delivered `scroll` event rendered a **stale** progress (the page moved but the scroll-linked value didn't), then snapped to the correct value on the next event — the visible jump.

## Fix

Read the scroll position **on the frame loop** while the container is scrolling, instead of relying solely on `scroll`-event delivery. This is the standard approach for scroll-linked animation (e.g. GSAP ScrollTrigger, Locomotive) and decouples updates from event timing, so every painted frame uses the latest scroll position.

To preserve Motion's idle-sleep behaviour, the per-frame read stops once the scroll position has been stable for a short window (`maxSettleFrames`), and a subsequent `scroll`/`resize` event restarts it. There is **no perpetual rAF when the page is static**.

## Tests

Added a regression test in `scroll/__tests__/index.test.ts` that advances the frame loop **without** dispatching a `scroll` event after the scroll position changes, and asserts the reported progress stays in sync. It fails against the previous event-driven implementation (progress stays stale) and passes with the frame-loop read.

The visual jitter itself is a compositor/main-thread timing effect that can't be reproduced deterministically in JSDOM/Electron (programmatic scrolling sets `scrollTop` synchronously, like the scrollbar path), so the unit test is the regression gate for the underlying behaviour.

- All 51 scroll-related unit tests pass.
- Full framer-motion client suite: 776 passed. (The only failing suites — `motion/__tests__/component` and `types` — fail identically on a clean checkout because the package's own `dist` isn't built in this worktree; unrelated to this change.)

Fixes #2716

🤖 Generated with [Claude Code](https://claude.com/claude-code)