### PR TITLE
Fix Safari opacity flash after WAAPI animations

### DIFF
--- a/packages/motion-dom/src/animation/NativeAnimation.ts
+++ b/packages/motion-dom/src/animation/NativeAnimation.ts
@@ -106,6 +106,8 @@ export class NativeAnimation<T extends AnyResolvedKeyframe>
                     this.updateMotionValue(keyframe)
                 }
 
+                this.commitStyles()
+
                 /**
                  * If we can, we want to commit the final style as set by the user,
                  * rather than the computed keyframe value supplied by the animation.

--- a/packages/motion-dom/src/animation/__tests__/NativeAnimation.test.ts
+++ b/packages/motion-dom/src/animation/__tests__/NativeAnimation.test.ts
@@ -2,12 +2,10 @@ import { motionValue } from "../../value"
 import { NativeAnimationExtended } from "../NativeAnimationExtended"
 
 /**
- * Tests for the Firefox opacity bug (issue #3552) where the WAAPI animation's
- * onfinish handler needed to commit the final style to the element's inline
- * styles before cancelling the animation. Without this, there was a timing
- * window in Firefox where the WAAPI fill was removed (via cancel()) before
- * the scheduled render could apply the correct value, causing a visual flash
- * back to the initial value.
+ * Tests for WAAPI completion bugs where cancelling the animation before its
+ * final styles are committed can briefly reveal the underlying initial style.
+ * Issue #3552 needed the final inline style set synchronously for Firefox,
+ * while issue #3778 needs the WAAPI styles committed before cancel for Safari.
  */
 describe("NativeAnimation - onfinish style commit", () => {
     let mockAnimation: any
@@ -15,6 +13,7 @@ describe("NativeAnimation - onfinish style commit", () => {
     beforeEach(() => {
         mockAnimation = {
             cancel: jest.fn(),
+            commitStyles: jest.fn(),
             onfinish: null,
             playbackRate: 1,
             currentTime: 300,
@@ -62,5 +61,27 @@ describe("NativeAnimation - onfinish style commit", () => {
          * the correct value back to the element.
          */
         expect(element.style.opacity).toBe("1")
+    })
+
+    test("commits WAAPI styles before cancelling on finish", () => {
+        const element = document.createElement("div")
+        document.body.appendChild(element)
+
+        new NativeAnimationExtended({
+            element,
+            name: "opacity",
+            keyframes: [0, 1],
+            duration: 300,
+            ease: "easeOut",
+        } as any)
+
+        mockAnimation.onfinish?.()
+
+        expect(mockAnimation.commitStyles).toHaveBeenCalledTimes(1)
+        expect(
+            mockAnimation.commitStyles.mock.invocationCallOrder[0]
+        ).toBeLessThan(mockAnimation.cancel.mock.invocationCallOrder[0])
+
+        element.remove()
     })
 })


### PR DESCRIPTION
## Summary
- commit the finished WAAPI effect to the element before writing the final keyframe and cancelling the animation
- prevent iOS Safari from briefly revealing the underlying initial opacity during the compositor-to-inline-style handoff
- add a regression test that verifies `commitStyles()` runs before `cancel()`

Fixes #3778

## Test plan
- [x] `yarn build`
- [x] `yarn turbo run test --filter=motion-dom` (496 passed, 3 skipped)
- [x] ESLint on both changed files (0 errors; existing boundary-type warnings only)
- [ ] `yarn lint` (blocked by pre-existing `dev/react` lint debt: 52 errors and 25 warnings)

The visual flash is specific to iOS Safari and cannot be reproduced in JSDOM or desktop browser CI, so the regression gate tests the underlying WAAPI handoff ordering directly.

Made with [Cursor](https://cursor.com)