### PR TITLE
Remove automatic @emotion/is-prop-valid loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## Unreleased
+
+### Breaking changes
+
+-   Removed implicit `@emotion/is-prop-valid` loading. Applications using `styled(motion.div)` should install `@emotion/is-prop-valid` and pass it to `<MotionConfig isValidProp={isPropValid}>`. This configuration is scoped to that `MotionConfig` subtree.
+
 ## [12.43.0] 2026-07-27
 
 ### Added

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -99,14 +99,10 @@
         "three": "0.137.0"
     },
     "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
     },
     "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-            "optional": true
-        },
         "react": {
             "optional": true
         },

--- a/packages/framer-motion/src/components/MotionConfig/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/components/MotionConfig/__tests__/index.test.tsx
@@ -5,19 +5,73 @@ import { render } from "../../../jest.setup"
 import { motion } from "../../../render/components/motion"
 
 describe("custom properties", () => {
-    test("renders", () => {
+    test("isValidProp is scoped to children", () => {
         const Component = () => {
             return (
-                <MotionConfig isValidProp={(key) => key !== "data-foo"}>
-                    <motion.div data-foo="bar" data-bar="foo" />
-                </MotionConfig>
+                <>
+                    <MotionConfig isValidProp={(key) => key !== "data-foo"}>
+                        <motion.div
+                            id="inside"
+                            data-foo="bar"
+                            data-bar="foo"
+                        />
+                    </MotionConfig>
+                    <motion.div id="outside" data-foo="bar" />
+                </>
             )
         }
 
-        const { container } = render(<Component />)
+        const { container, rerender } = render(<Component />)
 
-        expect(container.firstChild).not.toHaveAttribute("data-foo")
-        expect(container.firstChild).toHaveAttribute("data-bar")
+        expect(container.querySelector("#inside")).not.toHaveAttribute(
+            "data-foo"
+        )
+        expect(container.querySelector("#inside")).toHaveAttribute("data-bar")
+        expect(container.querySelector("#outside")).toHaveAttribute("data-foo")
+
+        rerender(<motion.div id="after" data-foo="bar" />)
+        expect(container.querySelector("#after")).toHaveAttribute("data-foo")
+    })
+
+    test("nested isValidProp overrides restore the parent validator", () => {
+        const { container } = render(
+            <MotionConfig isValidProp={(key) => key !== "data-outer"}>
+                <motion.div
+                    id="outer-before"
+                    data-outer="outer"
+                    data-inner="inner"
+                />
+                <MotionConfig isValidProp={(key) => key !== "data-inner"}>
+                    <motion.div
+                        id="inner"
+                        data-outer="outer"
+                        data-inner="inner"
+                    />
+                </MotionConfig>
+                <motion.div
+                    id="outer-after"
+                    data-outer="outer"
+                    data-inner="inner"
+                />
+            </MotionConfig>
+        )
+
+        expect(container.querySelector("#outer-before")).not.toHaveAttribute(
+            "data-outer"
+        )
+        expect(container.querySelector("#outer-before")).toHaveAttribute(
+            "data-inner"
+        )
+        expect(container.querySelector("#inner")).toHaveAttribute("data-outer")
+        expect(container.querySelector("#inner")).not.toHaveAttribute(
+            "data-inner"
+        )
+        expect(container.querySelector("#outer-after")).not.toHaveAttribute(
+            "data-outer"
+        )
+        expect(container.querySelector("#outer-after")).toHaveAttribute(
+            "data-inner"
+        )
     })
 })
 

--- a/packages/framer-motion/src/components/MotionConfig/index.tsx
+++ b/packages/framer-motion/src/components/MotionConfig/index.tsx
@@ -4,15 +4,10 @@ import * as React from "react"
 import { useContext, useMemo } from "react"
 import { resolveTransition } from "motion-dom"
 import { MotionConfigContext } from "../../context/MotionConfigContext"
-import {
-    loadExternalIsValidProp,
-    IsValidProp,
-} from "../../render/dom/utils/filter-props"
 import { useConstant } from "../../utils/use-constant"
 
 export interface MotionConfigProps extends Partial<MotionConfigContext> {
     children?: React.ReactNode
-    isValidProp?: IsValidProp
 }
 
 /**
@@ -32,13 +27,7 @@ export interface MotionConfigProps extends Partial<MotionConfigContext> {
  *
  * @public
  */
-export function MotionConfig({
-    children,
-    isValidProp,
-    ...config
-}: MotionConfigProps) {
-    isValidProp && loadExternalIsValidProp(isValidProp)
-
+export function MotionConfig({ children, ...config }: MotionConfigProps) {
     /**
      * Inherit props from any parent MotionConfig components
      */
@@ -67,6 +56,7 @@ export function MotionConfig({
             config.transformPagePoint,
             config.reducedMotion,
             config.skipAnimations,
+            config.isValidProp,
         ]
     )
 

--- a/packages/framer-motion/src/context/MotionConfigContext.tsx
+++ b/packages/framer-motion/src/context/MotionConfigContext.tsx
@@ -5,6 +5,7 @@ import { TransformPoint } from "motion-utils"
 import { createContext } from "react"
 
 export type ReducedMotionConfig = "always" | "never" | "user"
+export type IsValidProp = (key: string) => boolean
 
 /**
  * @public
@@ -53,6 +54,13 @@ export interface MotionConfigContext {
      */
     skipAnimations?: boolean
 
+    /**
+     * Determines whether a prop should be forwarded to the DOM.
+     * Useful when wrapping Motion components with a styling library.
+     *
+     * @public
+     */
+    isValidProp?: IsValidProp
 }
 
 /**

--- a/packages/framer-motion/src/motion/index.tsx
+++ b/packages/framer-motion/src/motion/index.tsx
@@ -103,7 +103,7 @@ export function createMotionComponent<
             layoutId: useLayoutId(props),
         }
 
-        const { isStatic } = configAndProps
+        const { isStatic, isValidProp } = configAndProps
 
         const context = useCreateMotionContext<HTMLElement | SVGElement>(props)
 
@@ -153,7 +153,8 @@ export function createMotionComponent<
                     visualState,
                     isStatic,
                     forwardMotionProps,
-                    isSVG
+                    isSVG,
+                    isValidProp
                 )}
             </MotionContext.Provider>
         )

--- a/packages/framer-motion/src/render/dom/use-render.ts
+++ b/packages/framer-motion/src/render/dom/use-render.ts
@@ -2,6 +2,7 @@
 
 import { isMotionValue } from "motion-dom"
 import { Fragment, createElement, useMemo } from "react"
+import type { IsValidProp } from "../../context/MotionConfigContext"
 import { MotionProps } from "../../motion/types"
 import { VisualState } from "../../motion/utils/use-visual-state"
 import { HTMLRenderState } from "../html/types"
@@ -24,7 +25,8 @@ export function useRender<
     }: VisualState<HTMLElement | SVGElement, HTMLRenderState | SVGRenderState>,
     isStatic: boolean,
     forwardMotionProps: boolean = false,
-    isSVG?: boolean
+    isSVG?: boolean,
+    isValidProp?: IsValidProp
 ) {
     const useVisualProps =
         (isSVG ?? isSVGComponent(Component)) ? useSVGProps : useHTMLProps
@@ -38,7 +40,8 @@ export function useRender<
     const filteredProps = filterProps(
         props,
         typeof Component === "string",
-        forwardMotionProps
+        forwardMotionProps,
+        isValidProp
     )
     const elementProps =
         Component !== Fragment ? { ...filteredProps, ...visualProps, ref } : {}

--- a/packages/framer-motion/src/render/dom/utils/__tests__/filter-props.test.ts
+++ b/packages/framer-motion/src/render/dom/utils/__tests__/filter-props.test.ts
@@ -1,8 +1,43 @@
 import "../../../../jest.setup"
 import * as fs from "fs"
 import * as path from "path"
+import type { MotionProps } from "../../../../motion/types"
+import { filterProps } from "../filter-props"
 
 describe("filter-props", () => {
+    it("forwards arbitrary non-Motion props by default", () => {
+        const props = {
+            id: "test",
+            customAttribute: "value",
+            animate: { opacity: 1 },
+        } as MotionProps
+
+        expect(filterProps(props, true, false)).toEqual({
+            id: "test",
+            customAttribute: "value",
+        })
+    })
+
+    it("uses an injected validator for DOM props", () => {
+        const onClick = () => {}
+        const props = {
+            id: "test",
+            "data-foo": "bar",
+            customAttribute: "value",
+            animate: { opacity: 1 },
+            onClick,
+            onTap: () => {},
+        } as MotionProps
+        const isValidProp = (key: string) =>
+            key === "id" || key === "data-foo"
+
+        expect(filterProps(props, true, false, isValidProp)).toEqual({
+            id: "test",
+            "data-foo": "bar",
+            onClick,
+        })
+    })
+
     it("does not load @emotion/is-prop-valid at runtime", () => {
         const source = fs.readFileSync(
             path.resolve(__dirname, "../filter-props.ts"),

--- a/packages/framer-motion/src/render/dom/utils/__tests__/filter-props.test.ts
+++ b/packages/framer-motion/src/render/dom/utils/__tests__/filter-props.test.ts
@@ -3,17 +3,32 @@ import * as fs from "fs"
 import * as path from "path"
 
 describe("filter-props", () => {
-    it("should not use statically-analyzable require for @emotion/is-prop-valid", () => {
+    it("does not load @emotion/is-prop-valid at runtime", () => {
         const source = fs.readFileSync(
             path.resolve(__dirname, "../filter-props.ts"),
             "utf8"
         )
-        // Webpack and other bundlers (e.g. Storybook) statically analyze
-        // require() calls and fail at build time when the module isn't
-        // installed — even if the require is inside a try-catch.
-        // The optional dependency must be loaded via a non-analyzable pattern.
-        expect(source).not.toMatch(
-            /require\s*\(\s*["'`]@emotion\/is-prop-valid["'`]\s*\)/
-        )
+
+        expect(source).not.toContain("require(")
+    })
+
+    it("does not declare @emotion/is-prop-valid as an optional peer", () => {
+        const packageJsonPaths = [
+            path.resolve(__dirname, "../../../../../package.json"),
+            path.resolve(__dirname, "../../../../../../motion/package.json"),
+        ]
+
+        packageJsonPaths.forEach((packageJsonPath) => {
+            const packageJson = JSON.parse(
+                fs.readFileSync(packageJsonPath, "utf8")
+            )
+
+            expect(
+                packageJson.peerDependencies?.["@emotion/is-prop-valid"]
+            ).toBeUndefined()
+            expect(
+                packageJson.peerDependenciesMeta?.["@emotion/is-prop-valid"]
+            ).toBeUndefined()
+        })
     })
 })

--- a/packages/framer-motion/src/render/dom/utils/filter-props.ts
+++ b/packages/framer-motion/src/render/dom/utils/filter-props.ts
@@ -1,23 +1,19 @@
 import { isMotionValue } from "motion-dom"
+import type { IsValidProp } from "../../../context/MotionConfigContext"
 import type { MotionProps } from "../../../motion/types"
 import { isValidMotionProp } from "../../../motion/utils/valid-prop"
 
-let shouldForward = (key: string) => !isValidMotionProp(key)
-
-export type IsValidProp = (key: string) => boolean
-
-export function loadExternalIsValidProp(isValidProp?: IsValidProp) {
-    if (typeof isValidProp !== "function") return
-
-    // Explicitly filter our events
-    shouldForward = (key: string) =>
-        key.startsWith("on") ? !isValidMotionProp(key) : isValidProp(key)
+function shouldForward(key: string, isValidProp?: IsValidProp) {
+    return key.startsWith("on")
+        ? !isValidMotionProp(key)
+        : isValidProp?.(key) ?? !isValidMotionProp(key)
 }
 
 export function filterProps(
     props: MotionProps,
     isDom: boolean,
-    forwardMotionProps: boolean
+    forwardMotionProps: boolean,
+    isValidProp?: IsValidProp
 ) {
     const filteredProps: MotionProps = {}
 
@@ -34,7 +30,7 @@ export function filterProps(
         if (isMotionValue(props[key as keyof typeof props])) continue
 
         if (
-            shouldForward(key) ||
+            shouldForward(key, isValidProp) ||
             (forwardMotionProps === true && isValidMotionProp(key)) ||
             (!isDom && !isValidMotionProp(key)) ||
             // If trying to use native HTML drag events, forward drag listeners

--- a/packages/framer-motion/src/render/dom/utils/filter-props.ts
+++ b/packages/framer-motion/src/render/dom/utils/filter-props.ts
@@ -14,34 +14,6 @@ export function loadExternalIsValidProp(isValidProp?: IsValidProp) {
         key.startsWith("on") ? !isValidMotionProp(key) : isValidProp(key)
 }
 
-/**
- * Emotion and Styled Components both allow users to pass through arbitrary props to their components
- * to dynamically generate CSS. They both use the `@emotion/is-prop-valid` package to determine which
- * of these should be passed to the underlying DOM node.
- *
- * However, when styling a Motion component `styled(motion.div)`, both packages pass through *all* props
- * as it's seen as an arbitrary component rather than a DOM node. Motion only allows arbitrary props
- * passed through the `custom` prop so it doesn't *need* the payload or computational overhead of
- * `@emotion/is-prop-valid`, however to fix this problem we need to use it.
- *
- * By making it an optionalDependency we can offer this functionality only in the situations where it's
- * actually required.
- */
-try {
-    /**
-     * We attempt to import this package but require won't be defined in esm environments, in that case
-     * isPropValid will have to be provided via `MotionContext`. In a 6.0.0 this should probably be removed
-     * in favour of explicit injection.
-     *
-     * String concatenation prevents bundlers like webpack (e.g. Storybook)
-     * from statically resolving this optional dependency at build time.
-     */
-    const emotionPkg = "@emotion/is-prop-" + "valid"
-    loadExternalIsValidProp(require(emotionPkg).default)
-} catch {
-    // We don't need to actually do anything here - the fallback is the existing `isPropValid`.
-}
-
 export function filterProps(
     props: MotionProps,
     isDom: boolean,

--- a/packages/motion/package.json
+++ b/packages/motion/package.json
@@ -80,14 +80,10 @@
         "tslib": "^2.4.0"
     },
     "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
     },
     "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-            "optional": true
-        },
         "react": {
             "optional": true
         },

--- a/plans/issues/README.md
+++ b/plans/issues/README.md
@@ -161,7 +161,7 @@ plan's own gate is satisfied). Classifications:
 | [issue-2658](issue-2658.md) | P2 | M | Keyboard-accessible Reorder via context moveByOffset |
 | [issue-1935](issue-1935.md) | P2 | L | layoutRoot-relative shared layout animation (absorbs issue-2514 scenario) |
 | [issue-3173](issue-3173.md) | P2 | L | AnimateSuspense — BUILD / DOCS / REJECT gate, then probe-pattern design |
-| [issue-2652](issue-2652.md) | P2 | S–M | Drop implicit `@emotion/is-prop-valid` require (breaking; next major) |
+| [issue-2652](issue-2652.md) | P2 | S–M | APPROVED Option A — PR #3783; breaking, next major |
 | [issue-2579](issue-2579.md) | P2 | M | useInView: re-register when ref.current null at first render (real bug shaped as feature) |
 | [issue-2603](issue-2603.md) | P3 | S | onReorder second arg `{value, from, to}` |
 | [issue-2189](issue-2189.md) | P3 | S/M | scrollXMax/scrollYMax on useScroll, or answer with `scrollInfo()` |

--- a/plans/issues/issue-2652.md
+++ b/plans/issues/issue-2652.md
@@ -123,3 +123,14 @@ breaking changes ride the next major.
 - README row has no recorded option → do nothing.
 - Removing the peer dep breaks any in-repo test/dev app that imports
   `@emotion/is-prop-valid` implicitly → report before working around.
+
+## Execution notes
+
+- Maintainer approved Option A on 2026-08-05 and confirmed this should ship in
+  the next major release.
+- PR #3783 removes implicit loading and the optional peer dependency, and
+  documents explicit `<MotionConfig isValidProp>` injection.
+- `isValidProp` was moved into `MotionConfigContext` rather than retaining the
+  plan's module-global loader, making validators subtree-scoped and safe for
+  sibling, nested, unmounted, and SSR trees.
+- Added direct filtering tests plus `MotionConfig` scope and nesting coverage.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7523,12 +7523,9 @@ __metadata:
     three: 0.137.0
     tslib: ^2.4.0
   peerDependencies:
-    "@emotion/is-prop-valid": "*"
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
-    "@emotion/is-prop-valid":
-      optional: true
     react:
       optional: true
     react-dom:
@@ -10773,12 +10770,9 @@ __metadata:
     framer-motion: ^12.43.0
     tslib: ^2.4.0
   peerDependencies:
-    "@emotion/is-prop-valid": "*"
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
-    "@emotion/is-prop-valid":
-      optional: true
     react:
       optional: true
     react-dom:


### PR DESCRIPTION
## Summary
- remove implicit runtime loading of `@emotion/is-prop-valid`, avoiding ESM/Vite resolution failures
- replace the module-global validator with subtree-scoped `MotionConfig` context
- remove the obsolete optional peer from `motion` and `framer-motion`
- cover default forwarding, explicit validation, sibling isolation, unmounting, and nested overrides

Fixes #2652

## Breaking change

This changes observable behavior for CommonJS consumers that relied on automatic `@emotion/is-prop-valid` discovery. It should ship in the next major release, not a Motion 12 minor.

The affected composition is primarily `styled(motion.div)`: styling libraries treat the Motion component as a custom component and can forward styling-only props into it. Plain `motion.div` and `motion(styled.div)` do not normally need this integration.

## Migration

Install the validator directly in applications that need it:

```bash
npm install @emotion/is-prop-valid
```

Then inject it at the relevant tree boundary:

```tsx
import isPropValid from "@emotion/is-prop-valid"
import { MotionConfig } from "motion/react"

<MotionConfig isValidProp={isPropValid}>
    <App />
</MotionConfig>
```

`isValidProp` now applies only to descendants of that `MotionConfig`. Sibling trees are unaffected, nested configs override their parent, and removing a config restores the parent/default behavior. Applications may alternatively filter styling props with their styling library's transient-prop or `shouldForwardProp` API.

`@emotion/is-prop-valid` is no longer a peer dependency because Motion no longer imports it. Applications using this migration must declare it as their own dependency.

## Test plan
- [x] `yarn build`
- [x] Scoped filtering regression tests: 2 suites, 11 passed
- [x] Framer Motion client Jest: 96 suites, 805 passed, 7 skipped
- [x] Framer Motion SSR Jest: 3 suites, 49 passed
- [x] ESLint on touched TypeScript files: 0 errors (pre-existing warnings remain)
- [ ] `yarn lint` (repository-wide lint is already blocked by 52 errors and 25 warnings in `dev/react`)