### PR TITLE
Fix AnimatePresence propagate with empty children

### DIFF
--- a/dev/react/src/tests/animate-presence-propagate-empty.tsx
+++ b/dev/react/src/tests/animate-presence-propagate-empty.tsx
@@ -1,0 +1,31 @@
+import { AnimatePresence, motion } from "framer-motion"
+import { useState } from "react"
+
+export const App = () => {
+    const [show, setShow] = useState(true)
+    const [exitCompleteCount, setExitCompleteCount] = useState(0)
+
+    return (
+        <>
+            <button id="toggle" onClick={() => setShow(false)}>
+                Toggle section
+            </button>
+            <span id="exit-complete-count">{exitCompleteCount}</span>
+            <AnimatePresence
+                onExitComplete={() =>
+                    setExitCompleteCount((count) => count + 1)
+                }
+            >
+                {show && (
+                    <motion.section
+                        id="section"
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.1 }}
+                    >
+                        <AnimatePresence propagate>{null}</AnimatePresence>
+                    </motion.section>
+                )}
+            </AnimatePresence>
+        </>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-presence-propagate-empty.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-propagate-empty.ts
@@ -1,0 +1,11 @@
+describe("AnimatePresence propagate", () => {
+    it("Completes exit when there are no children", () => {
+        cy.visit("?test=animate-presence-propagate-empty")
+            .get("#toggle")
+            .click()
+            .get("#section")
+            .should("not.exist")
+            .get("#exit-complete-count")
+            .should("have.text", "1")
+    })
+})

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -100,6 +100,12 @@ export const AnimatePresence = ({
     const [renderedChildren, setRenderedChildren] = useState(presentChildren)
 
     useIsomorphicLayoutEffect(() => {
+        if (propagate && !isParentPresent && !renderedChildren.length) {
+            safeToRemove?.()
+        }
+    }, [isParentPresent, propagate, renderedChildren.length, safeToRemove])
+
+    useIsomorphicLayoutEffect(() => {
         isInitialRender.current = false
         pendingPresentChildren.current = presentChildren
 


### PR DESCRIPTION
## Summary
- complete a propagated presence exit immediately when the nested `AnimatePresence` has no rendered children
- add browser regression coverage based on the issue reproduction
- verify the parent exits and `onExitComplete` fires exactly once

Fixes #3777

## Test plan
- [x] Confirmed the new Cypress test fails before the fix because the outer section remains mounted
- [x] `yarn build`
- [x] AnimatePresence Jest suite (40 tests)
- [x] Cypress regression test on React 18
- [x] Cypress regression test on React 19
- [x] Targeted ESLint on all changed files (no errors; the existing AnimatePresence file reports its two pre-existing warnings)

## Notes
- Repository-wide `yarn lint` still fails on 52 pre-existing errors in unrelated React examples/tests.

Made with [Cursor](https://cursor.com)