### PR TITLE
Replace per-node ancestor walks with cumulative path transforms

### DIFF
--- a/packages/motion-dom/src/projection/geometry/delta-apply.ts
+++ b/packages/motion-dom/src/projection/geometry/delta-apply.ts
@@ -68,6 +68,16 @@ const TREE_SCALE_SNAP_MIN = 0.999999999999
 const TREE_SCALE_SNAP_MAX = 1.0000000000001
 
 /**
+ * Snap a cumulative tree scale back to 1 if it's within a non-perceivable
+ * threshold. This will help reduce useless scales getting rendered.
+ */
+export function snapTreeScale(scale: number): number {
+    return scale < TREE_SCALE_SNAP_MAX && scale > TREE_SCALE_SNAP_MIN
+        ? 1.0
+        : scale
+}
+
+/**
  * Apply a tree of deltas to a box. We do this to calculate the effect of all the transforms
  * in a tree upon our box before then calculating how to project it into our desired viewport-relative box
  *
@@ -94,14 +104,10 @@ export function applyTreeDeltas(
 
         /**
          * TODO: Prefer to remove this, but currently we have motion components with
-         * display: contents in Framer.
+         * display: contents in Framer. The flag is cached in setOptions as
+         * resolving the props chain here is a hotspot.
          */
-        const { visualElement } = node.options
-        if (
-            visualElement &&
-            visualElement.props.style &&
-            visualElement.props.style.display === "contents"
-        ) {
+        if (node.isDisplayContents) {
             continue
         }
 
@@ -129,22 +135,8 @@ export function applyTreeDeltas(
         }
     }
 
-    /**
-     * Snap tree scale back to 1 if it's within a non-perceivable threshold.
-     * This will help reduce useless scales getting rendered.
-     */
-    if (
-        treeScale.x < TREE_SCALE_SNAP_MAX &&
-        treeScale.x > TREE_SCALE_SNAP_MIN
-    ) {
-        treeScale.x = 1.0
-    }
-    if (
-        treeScale.y < TREE_SCALE_SNAP_MAX &&
-        treeScale.y > TREE_SCALE_SNAP_MIN
-    ) {
-        treeScale.y = 1.0
-    }
+    treeScale.x = snapTreeScale(treeScale.x)
+    treeScale.y = snapTreeScale(treeScale.y)
 }
 
 export function translateAxis(axis: Axis, distance: number) {

--- a/packages/motion-dom/src/projection/node/create-projection-node.ts
+++ b/packages/motion-dom/src/projection/node/create-projection-node.ts
@@ -38,6 +38,7 @@ import { copyAxisDeltaInto, copyAxisInto, copyBoxInto } from "../geometry/copy"
 import {
     applyBoxDelta,
     applyTreeDeltas,
+    snapTreeScale,
     transformBox,
     translateAxis,
 } from "../geometry/delta-apply"
@@ -72,6 +73,7 @@ import {
     ProjectionNodeConfig,
     ProjectionNodeOptions,
     ScrollMeasurements,
+    PathTransform,
 } from "./types"
 
 const metrics = {
@@ -858,6 +860,12 @@ export function createProjectionNode<I>({
             this.projectionUpdateScheduled = false
 
             /**
+             * Invalidate every node's cached cumulative path transform
+             * (see updatePathTransform).
+             */
+            this.pathTransformSweep++
+
+            /**
              * Reset debug counts. Manually resetting rather than creating a new
              * object each frame.
              */
@@ -1153,7 +1161,26 @@ export function createProjectionNode<I>({
                 crossfade:
                     options.crossfade !== undefined ? options.crossfade : true,
             }
+
+            /**
+             * Cache the display: contents check. It's read for every
+             * ancestor of every projecting node each frame, and resolving
+             * the props chain there is a hotspot.
+             */
+            const { visualElement } = this.options
+            const style = visualElement
+                ? (visualElement.props as { style?: MotionStyle }).style
+                : undefined
+            this.isDisplayContents =
+                !!style && (style as { display?: string }).display === "contents"
         }
+
+        /**
+         * Whether the underlying element is display: contents, cached in
+         * setOptions. Read by applyTreeDeltas and updatePathTransform for
+         * every ancestor of every projecting node each frame.
+         */
+        isDisplayContents = false
 
         clearMeasurements() {
             this.scroll = undefined
@@ -1393,6 +1420,79 @@ export function createProjectionNode<I>({
 
         hasProjected: boolean = false
 
+        /**
+         * Cumulative transform of all ancestors' projection deltas,
+         * expressed per axis as an affine map (p -> a * p + b) plus the
+         * cumulative scale product (treeScale). Each ancestor's delta is
+         * an axis-aligned translate/scale, so the whole path composes in
+         * closed form. This replaces the per-node walk over the full
+         * ancestor path (applyTreeDeltas) with an O(1) composition from
+         * the parent's cached transform - the projection sweep is
+         * depth-sorted so parents are always resolved first.
+         *
+         * Only used for non-shared projections: shared transitions also
+         * apply scroll offsets and ancestor latestValues transforms whose
+         * origins depend on the box being projected, so they can't share
+         * a single per-layer map.
+         */
+        pathTransformSweep = 0
+        pathTransformAt = -1
+        pathTransform: PathTransform = {
+            ax: 1,
+            bx: 0,
+            ay: 1,
+            by: 0,
+            sx: 1,
+            sy: 1,
+        }
+
+        updatePathTransform(): PathTransform {
+            const pt = this.pathTransform
+            const sweep = this.root.pathTransformSweep
+
+            if (this.pathTransformAt === sweep) return pt
+            this.pathTransformAt = sweep
+
+            const { parent } = this
+            if (!parent) {
+                pt.ax = pt.ay = pt.sx = pt.sy = 1
+                pt.bx = pt.by = 0
+                return pt
+            }
+
+            const parentTransform = parent.updatePathTransform()
+            pt.ax = parentTransform.ax
+            pt.bx = parentTransform.bx
+            pt.ay = parentTransform.ay
+            pt.by = parentTransform.by
+            pt.sx = parentTransform.sx
+            pt.sy = parentTransform.sy
+
+            const delta = parent.projectionDelta
+            if (delta && !parent.isDisplayContents) {
+                const { x, y } = delta
+                /**
+                 * Compose the parent's own delta after its ancestors':
+                 * F(p) = scale * p + (originPoint * (1 - scale) + translate)
+                 */
+                pt.ax *= x.scale
+                pt.bx =
+                    x.scale * pt.bx +
+                    x.originPoint * (1 - x.scale) +
+                    x.translate
+                pt.sx *= x.scale
+
+                pt.ay *= y.scale
+                pt.by =
+                    y.scale * pt.by +
+                    y.originPoint * (1 - y.scale) +
+                    y.translate
+                pt.sy *= y.scale
+            }
+
+            return pt
+        }
+
         calcProjection() {
             const lead = this.getLead()
             const isShared = Boolean(this.resumingFrom) || this !== lead
@@ -1459,13 +1559,29 @@ export function createProjectionNode<I>({
             /**
              * Apply all the parent deltas to this box to produce the corrected box. This
              * is the layout box, as it will appear on screen as a result of the transforms of its parents.
+             *
+             * Non-shared projections use the cumulative path transform - a
+             * closed-form composition of every ancestor's delta, computed
+             * once per node per sweep - instead of walking the full
+             * ancestor path per node.
              */
-            applyTreeDeltas(
-                this.layoutCorrected,
-                this.treeScale,
-                this.path,
-                isShared
-            )
+            if (isShared) {
+                applyTreeDeltas(
+                    this.layoutCorrected,
+                    this.treeScale,
+                    this.path,
+                    true
+                )
+            } else {
+                const pt = this.updatePathTransform()
+                const box = this.layoutCorrected
+                box.x.min = pt.ax * box.x.min + pt.bx
+                box.x.max = pt.ax * box.x.max + pt.bx
+                box.y.min = pt.ay * box.y.min + pt.by
+                box.y.max = pt.ay * box.y.max + pt.by
+                this.treeScale.x = snapTreeScale(pt.sx)
+                this.treeScale.y = snapTreeScale(pt.sy)
+            }
 
             /**
              * If this layer needs to perform scale correction but doesn't have a target,

--- a/packages/motion-dom/src/projection/node/create-projection-node.ts
+++ b/packages/motion-dom/src/projection/node/create-projection-node.ts
@@ -1165,7 +1165,9 @@ export function createProjectionNode<I>({
             /**
              * Cache the display: contents check. It's read for every
              * ancestor of every projecting node each frame, and resolving
-             * the props chain there is a hotspot.
+             * the props chain there is a hotspot. Also refreshed once per
+             * node per frame in propagateDirtyNodes, as props can update
+             * without setOptions being called.
              */
             const { visualElement } = this.options
             const style = visualElement
@@ -1177,8 +1179,9 @@ export function createProjectionNode<I>({
 
         /**
          * Whether the underlying element is display: contents, cached in
-         * setOptions. Read by applyTreeDeltas and updatePathTransform for
-         * every ancestor of every projecting node each frame.
+         * setOptions and refreshed per frame in propagateDirtyNodes. Read
+         * by applyTreeDeltas and updatePathTransform for every ancestor
+         * of every projecting node each frame.
          */
         isDisplayContents = false
 
@@ -2409,6 +2412,18 @@ export function propagateDirtyNodes(node: IProjectionNode) {
     if (statsBuffer.value) {
         metrics.nodes++
     }
+
+    /**
+     * Refresh the display: contents cache once per node per frame -
+     * props can update between renders without setOptions being called.
+     * This keeps the check out of the per-ancestor inner loops
+     * (applyTreeDeltas/updatePathTransform).
+     */
+    const { visualElement } = node.options
+    const style = visualElement
+        ? (visualElement.props as { style?: { display?: string } }).style
+        : undefined
+    node.isDisplayContents = !!style && style.display === "contents"
 
     if (!node.parent) return
 

--- a/packages/motion-dom/src/projection/node/types.ts
+++ b/packages/motion-dom/src/projection/node/types.ts
@@ -37,6 +37,20 @@ export type LayoutEvents =
     | "animationStart"
     | "animationComplete"
 
+/**
+ * Cumulative ancestor projection transform, expressed per axis as an
+ * affine map (p -> a * p + b), plus the cumulative scale product
+ * (sx/sy, i.e. treeScale).
+ */
+export interface PathTransform {
+    ax: number
+    bx: number
+    ay: number
+    by: number
+    sx: number
+    sy: number
+}
+
 export interface IProjectionNode<I = unknown> {
     linkedParentVersion: number
     layoutVersion: number
@@ -112,6 +126,20 @@ export interface IProjectionNode<I = unknown> {
         targetStyle: CSSStyleDeclaration,
         styleProp?: MotionStyle
     ): void
+    /**
+     * Whether the underlying element is display: contents. Cached in
+     * setOptions so per-frame tree walks don't repeatedly resolve
+     * options.visualElement.props.style.
+     */
+    isDisplayContents: boolean
+    /**
+     * Cumulative affine transform of this node's ancestor projection
+     * deltas, cached per updateProjection sweep. Composed O(1) from the
+     * parent's cached transform - the projection sweep is depth-sorted so
+     * parents are always resolved first.
+     */
+    pathTransformSweep: number
+    updatePathTransform(): PathTransform
     clearMeasurements(): void
     resetTree(): void
 


### PR DESCRIPTION
## Summary

- `calcProjection` applied every ancestor's projection delta to each node's box via `applyTreeDeltas` — an O(nodes × depth) walk every frame.
- Each ancestor delta is an axis-aligned translate/scale, i.e. per axis an affine map (p → a·p + b), so a node's full ancestor correction composes in closed form from its parent's cached transform. Nodes now compute this once per `updateProjection` sweep (`updatePathTransform`, invalidated by a sweep counter; the sweep is depth-sorted so parents always resolve first), making the path work O(nodes).
- Shared transitions (`layoutId`/`resumingFrom`) keep the legacy walk: they interleave scroll offsets and ancestor `latestValues` transforms whose origins depend on the box being projected, so they don't compose into one per-layer map.
- Also caches the `display: contents` check in `setOptions` — resolving `options.visualElement.props.style` for every ancestor of every node each frame was itself a hotspot.

At depth 30 (1,200 nodes, deep-tree stress test) the path work measured 31.1ms → 9.2ms per 2s animation window; `applyTreeDeltas` drops out of the profile's top hotspots entirely. Break-even is at shallow depth (~5); the win scales with tree depth.

## Test plan

- [x] `motion-dom` + `framer-motion` unit suites (508 + 814 passing)
- [x] All layout Cypress specs (`layout*.ts`, 68 tests) against React 18
- [x] Profiled deep-tree layout stress before/after via V8 sampling profiler