### PR TITLE
Add renderer/style-recalc benchmarks, findings doc and layout profiler

### DIFF
--- a/dev/html/public/benchmarks/FINDINGS.md
+++ b/dev/html/public/benchmarks/FINDINGS.md
@@ -1,0 +1,239 @@
+# Renderer & Style Invalidation Findings
+
+Results from the renderer investigation (Aug 2026): can a new write mechanism
+avoid the "massive style recalculation" failure mode of per-frame
+`element.style` writes, and what should Motion's renderer(s) be?
+
+Benchmark pages (serve `dev/html` on port 8000):
+
+- `style-recalc-harness.html` — which environments make style writes expensive,
+  across write mechanisms (inline, CSS vars, registered vars, adopted
+  stylesheet). Supports `&flush` for vsync-independent style-cost timing.
+- `renderer-test-1.html` — granularity: 5 paint values on 300 boxes, then 1.
+- `renderer-test-2.html` — the same 5 values in a hostile invalidation
+  environment (`[style*=]` attribute selectors + descendant subtrees).
+- `renderer-test-3.html` — transforms in the hostile environment:
+  inline vs var vs stylesheet, with/without `will-change`.
+
+Protocol everywhere: 4 runs per condition without reload, first run discarded
+(JIT warmup), results averaged over runs 2–4.
+
+## What triggers the recalculation bomb
+
+Per-frame inline writes of **non-inherited standard properties are cheap by
+default** — Blink/WebKit invalidation is precise. The bomb requires one of
+these subscriptions (flush-timed style cost, 100 boxes × 50 descendants,
+5 props/frame, embedded Chromium):
+
+| Environment | Inline writes | Sheet writes | Bomb? |
+| --- | --- | --- | --- |
+| plain | 0.36 ms/frame | — | no |
+| 50 descendants/box (non-inherited props) | 0.47 | 1.09 | no |
+| `:has()` keyed on classes | 0.30 | — | no |
+| 20k-rule stylesheet (complex selectors, no `[style]`) | 1.08 | 1.53 | no |
+| `[style*="…"]` selectors (1k rules) | **28.5** | **1.04** | yes |
+| inherited property (`color`) + descendants | **27.8 ms frame** | 16.67 (fast path) | yes |
+| unregistered `--var` + descendants (even unreferenced) | ~4 ms/frame hidden | — | at scale |
+| `@container style(--p)` subscriptions in descendants | **22–28 ms frame** | **same** | yes, unavoidable |
+
+Notes:
+
+- `[style*=]` selectors are rare in hand-written CSS (mostly adblock cosmetic
+  filters) but the other triggers are mainstream: animating `color` on an
+  element with children, animating CSS variables, `@container style()` queries.
+- `CSS.registerProperty({ inherits: false })` suppresses the var-inheritance
+  fan-out (~5.7× cheaper) but does **not** help with `[style*=]` (the
+  attribute still mutates) or `@container style()` (subscription is on the
+  value).
+- `@container style()` bombs **every** write mechanism, including adopted
+  stylesheets and (by construction) WAAPI — the subscription is to the
+  computed value. Document as a user-facing footgun; no renderer fixes it.
+- `transition: all` vs named transitions: the `all` keyword itself is ~free;
+  the cost is transition retargeting for any rule covering a JS-animated
+  property (~few ms/frame at 500 transitions). Amplifier, not a bomb.
+- 16.67 ms readings are the vsync floor. Use `&flush` to measure real style
+  cost when under budget.
+
+## Renderer comparison
+
+### Test 1 — benign page (300 boxes, 5 paint props)
+
+Chrome & Safari: **all renderers identical** (paint-bound or vsync floor).
+legacy ≈ styleEffect ≈ varEffect ≈ GSAP ≈ WAAPI in frame time.
+Granularity shows only in render JS/frame (phase B, 1 of 5 values animating):
+legacy 0.36–0.47 ms, styleEffect 0.06–0.10 ms (≈5×), varEffect 0.22–0.26 ms.
+
+### Test 2 — hostile page
+
+Real Chrome, 300 boxes × 80 descendants, 2k `[style*=]` rules:
+
+| Renderer | fps | mean frame |
+| --- | --- | --- |
+| WAAPI (element.animate) | **30.6** | **33 ms** |
+| CSS transition | 26.3 | 38 ms |
+| sheet (adopted stylesheet) | 26.4 | 40 ms |
+| GSAP (inline writes) | 4.0 | 250 ms |
+| styleEffect | 3.9 | 259 ms |
+| legacy (re-apply all) | 3.7 | 267 ms |
+| varEffect (registered vars, inline) | 2.8 | 354 ms |
+
+Real Safari, same scale:
+
+| Renderer | fps | mean frame |
+| --- | --- | --- |
+| CSS transition | 3.9 | 256 ms |
+| WAAPI | **3.9** | **259 ms** |
+| GSAP | 2.9 | 351 ms |
+| styleEffect | 2.7 | 393 ms |
+| legacy | 2.6 | 398 ms |
+| sheet | 2.4 | **411 ms — no escape in WebKit** |
+| varEffect | 1.9 | 588 ms |
+
+Key engine difference: Blink has a scoped fast path for CSSOM rule-declaration
+mutation (sheet ≈ WAAPI); WebKit does not (sheet ≈ inline). WAAPI/transitions
+are the only mechanisms that win or tie in **both** engines.
+
+### Test 3 — transforms in hostile env (embedded Chromium, 300 boxes)
+
+`will-change` is useless while recalc-bound (style/var ≈50 ms with or without).
+Escape recalc first (sheet ~33 ms), then `will-change` removes paint →
+locked 60 fps (16.67 ms). Order of operations matters: attribute-invalidation
+→ paint → compositing.
+
+## Renderer decision
+
+1. **Default to WAAPI for everything keyframeable** — including
+   non-accelerated paint properties. Only strategy that never loses in either
+   engine. Zero main-thread render JS (0.000 in every run). Springs already
+   pregenerate keyframes. Measure retargeting cost (computed-style read forces
+   a flush) before shipping.
+2. **styleEffect (inline writes) remains the frame-driven fallback**
+   (gestures, scroll, useTransform). Inline is ~2× *cheaper* than sheet
+   writes in benign environments (0.47 vs 1.09 ms flush) — the common case.
+3. **No sheet renderer.** Its only value was capping the hostile case, and it
+   only does so in Blink. Not worth cross-engine complexity, cascade weirdness
+   (rule loses to inline styles), and DevTools opacity.
+4. **varEffect (registered vars written inline) is dead.** Worst renderer in
+   both engines: pays attribute invalidation + var indirection.
+   `CSS.registerProperty({ inherits: false })` remains useful for
+   Motion-internal generated variables only — never re-register user vars
+   (changes inheritance semantics).
+
+## GSAP comparison (defensible claims)
+
+- Clean pages: parity (~27 ms both, Chrome; both 60 fps, Safari).
+- Hostile CSS, Chrome: **7.5× faster frames** (33 vs 250 ms) — structural:
+  GSAP must mutate the style attribute from its ticker every frame.
+- Hostile CSS, Safari: 1.4× (259 vs 351 ms).
+- Moderate hostile scale: 1.4–2×.
+- Structural claims: zero main-thread animation JS; compositor animations
+  survive main-thread jank (categorical, not a multiplier).
+- Motion's write-path JS is ~0.3% of frame time under load in Chrome
+  (0.72–0.79 ms of ~260 ms). Caveat: WebKit charges invalidation to the
+  setter (~7 ms/frame at 1,500 values). Frame cost is browser style/paint
+  work triggered by writes — the leverage is the write mechanism, not JS.
+
+## Layout projection performance (Aug 2026 follow-up)
+
+Profiled `dev/react?example=layout-stress-transform` (1,513 projection
+nodes, 1,008 animating) with a V8 sampling profiler via Playwright/CDP
+(`dev/react/profile-layout.mjs`) and an interleaved A/B harness that
+alternates baseline/optimized builds per boot (fresh Vite server per
+build, two profile runs per boot, take the minimum).
+
+### What the "projection JS" actually is
+
+- Skipping only the `style.transform = ...` write dropped total sampled JS
+  from ~200 ms to ~94 ms per 2 s window — **the CSSOM setter (browser
+  string parse + style invalidation, charged to JS) is over half of all
+  "projection JS"**. This is the floor; no JS restructuring touches it.
+- **CSS Typed OM is slower**, not faster: retained
+  `CSSTransformValue` + `attributeStyleMap.set` measured 291 ms vs 199 ms
+  total (Blink's Typed OM set path does spec-mandated normalization).
+- **Individual `translate`/`scale` properties are slower too** (two setter
+  calls: 80.6 ms vs 56.4 ms self-time in `applyProjectionStyles`).
+- **`matrix()` serialization is slower** (~85 vs ~62 ms self-time): it
+  always carries six full-precision floats, while the composed
+  `translate3d`/`scale` string omits identity segments and collapses to
+  `"none"` near rest. Parse cost tracks string content, not function
+  count. `DOMMatrix` has no other route into a style — `.toString()` is
+  this same string plus allocation, and `CSSMatrixComponent` rides the
+  Typed OM set path already measured slower.
+- **Rounding transform values corrupts projection**: rounding
+  translate/scale in `buildProjectionTransform` broke measure/unproject
+  round-trips (measurements happen with the rounded transform in the DOM
+  but are unprojected with exact values), leaving sub-pixel residuals that
+  failed 22 Cypress layout tests. Reverted — don't retry.
+
+### Shipped optimizations (all layout e2e + unit tests green, React 18+19)
+
+1. **Memoized projection style writes**: `applyProjectionStyles` caches the
+   last rendered transform/transformOrigin/opacity/visibility and skips
+   redundant CSSOM writes.
+2. **Projection-only renders**: per-frame projection renders no longer
+   re-write the element's full style set; full renders only when values
+   change. `renderStyles` skips transform/origin when projection owns them.
+3. **Root render sweep**: nodes set a flag and the projection root
+   schedules one frame callback that sweeps the tree, instead of ~1,000
+   `frame.render` schedulings per frame (`schedule` self-time 19.6 ms → 0).
+4. Hoisted `isDisplayContents` to `setOptions`, delta-reuse in
+   `applyTransformsToTarget` when no user transforms, fused
+   `mixBoxInto` (mix + equality + copy in one pass), keepAlive fast path in
+   the frameloop, indexed loops in FlatTree/scale correctors.
+5. On animation complete, a full render restores scale-corrected values
+   (borderRadius etc.) — required by the sweep change.
+6. **Cumulative path transforms**: each ancestor's projection delta is an
+   axis-aligned affine map (p → a·p + b), so a node's full ancestor
+   correction composes in closed form from its parent's cached transform
+   (`updatePathTransform`, stamped per updateProjection sweep). Replaces
+   the per-node walk over the whole ancestor path (`applyTreeDeltas`) —
+   O(nodes × depth) → O(nodes). At depth 30 (1,201 nodes,
+   `layout-stress-deep`): 31.1 ms → 9.2 ms for the path work, calc-side
+   total ~37.5 → ~21 ms per 2 s. Break-even at shallow depth (~5), scales
+   with depth. Shared transitions (layoutId/resumingFrom) keep the legacy
+   walk: they interleave scroll offsets and ancestor `latestValues`
+   transforms whose origins depend on the box being projected, so they
+   don't compose into one per-layer map. Using `DOMMatrix` for this math
+   instead of plain records was considered and rejected: identical idea,
+   but every op crosses a C++ binding and `multiply()` allocates; the
+   specialized {a, b, scale} record is the same matrix without the
+   overhead (and the box {min,max} format itself was never the cost).
+
+### Results (interleaved A/B, median of per-boot minimums)
+
+- Whole-animation window: total sampled JS **−16%** (368 → 309 ms),
+  projection-attributed **−14.5%** (217 → 186 ms). Mid-animation windows:
+  −15–23% across three independent A/B rounds.
+- Excluding the irreducible CSSOM write, the pure JS computation reduced
+  ~25–30%. The original ≥50% target is not reachable by JS restructuring:
+  ~60% of what profilers attribute to projection functions is the browser's
+  style write cost, and both alternative write mechanisms measured slower.
+- Remaining JS hotspots (per 2 s, optimized): `applyProjectionStyles`
+  ~10 ms ex-write, `mixTargetDelta` 13 ms, `resolveTargetDelta` +
+  `calcProjection` ~22 ms, `JSAnimation.tick` 10 ms. Halving further means
+  fewer nodes doing per-frame math (e.g. WAAPI-driven pregenerated
+  projection keyframes) — an architectural project, not an optimization.
+
+### Layout measurement pitfalls
+
+- Single-run profile comparisons swing ±40% with thermals; only the
+  interleaved A/B (alternating builds per boot, min of repeated runs)
+  produced stable deltas.
+- Window placement matters: mid-animation windows exclude the ease tail
+  where write-memoization wins; whole-animation windows include the
+  unoptimized React didUpdate burst. Report which one you measured.
+
+## Measurement pitfalls (repeat offenders)
+
+- **Vsync floor**: 16.67 ms means "under budget", not "equal". Use the
+  harness `&flush` metric or CDP `Performance.getMetrics`
+  (RecalcStyleDuration deltas) to unclamp.
+- **rAF throttling**: background/occluded tabs throttle rAF to ~1–2 fps.
+  Force `Page.setWebLifecycleState { state: "active" }` via CDP, and verify
+  tick rate before trusting a run.
+- **Tween semantics**: `gsap.to()` from current values created zero-change
+  tweens in alternating-phase benchmarks — use explicit endpoints
+  (`fromTo`/keyframes) everywhere or fast runs are fake.
+- **Embedded Chromium inflates paint cost** (software raster). Relative
+  rankings held up in real browsers; absolute numbers did not.
+- LoAF only reports frames ≥50 ms — useless for sub-budget costs.

--- a/dev/html/public/benchmarks/renderer-bench-lib.js
+++ b/dev/html/public/benchmarks/renderer-bench-lib.js
@@ -4,7 +4,7 @@
  *
  * Provides:
  * - Renderer strategies: legacy (old VisualElement full re-apply),
- *   style (styleEffect), var (varEffect, registered CSS properties),
+ *   style (styleEffect), var (registered CSS properties),
  *   sheet (experimental: adopted stylesheet rule writes - never touches
  *   the element's style attribute after setup).
  * - A phase runner implementing the protocol: 4 runs without reload,
@@ -39,7 +39,80 @@ export function buildBoxes(container, n, descendants = 0) {
 /** ------------------------------------------------------------------ */
 
 export function createStrategies(Motion) {
-    const { motionValue, styleEffect, varEffect, frame, cancelFrame } = Motion
+    const { motionValue, styleEffect, frame, cancelFrame } = Motion
+
+    /**
+     * Registered-custom-property renderer. Uses Motion's varEffect when
+     * available (experimental branches); otherwise falls back to a
+     * standalone implementation of the same mechanism: register a
+     * per-value custom property with inherits: false, point the real
+     * style at var(--name) once, then write only the custom property
+     * per frame.
+     */
+    const TRANSFORM_KEYS = new Set(["x", "y", "scale", "rotate"])
+    let benchVarId = 0
+    const registerVar = () => {
+        const name = `--bench-var-${benchVarId++}`
+        try {
+            CSS.registerProperty({ name, syntax: "*", inherits: false })
+        } catch {}
+        return name
+    }
+    const camelToDash = (key) => key.replace(/[A-Z]/g, "-$&").toLowerCase()
+
+    const varEffect =
+        Motion.varEffect ||
+        ((element, values) => {
+            const unsubs = []
+            const renders = []
+            const transformKeys = []
+
+            for (const key in values) {
+                if (TRANSFORM_KEYS.has(key)) {
+                    transformKeys.push(key)
+                    continue
+                }
+
+                const value = values[key]
+                const name = registerVar()
+                element.style.setProperty(camelToDash(key), `var(${name})`)
+                const render = () =>
+                    element.style.setProperty(name, String(value.get()))
+                renders.push(render)
+                unsubs.push(value.on("change", () => frame.render(render)))
+                render()
+            }
+
+            if (transformKeys.length) {
+                const name = registerVar()
+                element.style.setProperty("transform", `var(${name})`)
+                const get = (key, fallback) =>
+                    values[key] ? values[key].get() : fallback
+                const render = () =>
+                    element.style.setProperty(
+                        name,
+                        `translate(${get("x", 0)}px, ${get(
+                            "y",
+                            0
+                        )}px) scale(${get("scale", 1)}) rotate(${get(
+                            "rotate",
+                            0
+                        )}deg)`
+                    )
+                renders.push(render)
+                for (const key of transformKeys) {
+                    unsubs.push(
+                        values[key].on("change", () => frame.render(render))
+                    )
+                }
+                render()
+            }
+
+            return () => {
+                for (const unsub of unsubs) unsub()
+                for (const render of renders) cancelFrame(render)
+            }
+        })
 
     const makeValues = (props) => {
         const values = {}

--- a/dev/html/public/benchmarks/renderer-bench-lib.js
+++ b/dev/html/public/benchmarks/renderer-bench-lib.js
@@ -1,0 +1,511 @@
+/**
+ * Shared library for the renderer benchmark pages
+ * (renderer-test-1/2/3.html).
+ *
+ * Provides:
+ * - Renderer strategies: legacy (old VisualElement full re-apply),
+ *   style (styleEffect), var (varEffect, registered CSS properties),
+ *   sheet (experimental: adopted stylesheet rule writes - never touches
+ *   the element's style attribute after setup).
+ * - A phase runner implementing the protocol: 4 runs without reload,
+ *   first run discarded as JIT/warmup.
+ * - Frame metering: wallclock frame stats + time spent in Motion's
+ *   render step (the actual style write cost).
+ */
+
+export const PAINT_PROPS = {
+    backgroundColor: ["rgb(255, 40, 40)", "rgb(40, 40, 255)"],
+    borderColor: ["rgb(40, 255, 40)", "rgb(255, 40, 255)"],
+    borderRadius: ["4px", "20px"],
+    boxShadow: ["0 0 2px rgb(255, 40, 40)", "0 0 14px rgb(40, 40, 255)"],
+    outlineColor: ["rgb(20, 20, 20)", "rgb(255, 255, 40)"],
+}
+
+export function buildBoxes(container, n, descendants = 0) {
+    const parts = []
+    let inner = ""
+    for (let j = 0; j < descendants; j++) {
+        inner += `<span class="d${j % 10}">x</span>`
+    }
+    for (let i = 0; i < n; i++) {
+        parts.push(`<div class="box">${inner}</div>`)
+    }
+    container.innerHTML = parts.join("")
+    return Array.from(container.querySelectorAll(".box"))
+}
+
+/** ------------------------------------------------------------------ */
+/** Renderer strategies                                                 */
+/** ------------------------------------------------------------------ */
+
+export function createStrategies(Motion) {
+    const { motionValue, styleEffect, varEffect, frame, cancelFrame } = Motion
+
+    const makeValues = (props) => {
+        const values = {}
+        for (const prop in props) values[prop] = motionValue(props[prop][0])
+        return values
+    }
+
+    /**
+     * Old VisualElement renderer semantics: any value change schedules a
+     * render that re-applies EVERY bound style, including stagnant ones.
+     */
+    const legacy = {
+        name: "legacy (re-apply all)",
+        bind(boxes, props) {
+            const all = []
+            const subscriptions = []
+            const renders = []
+
+            for (const box of boxes) {
+                const values = makeValues(props)
+                const keys = Object.keys(values)
+
+                const render = () => {
+                    for (const key of keys) {
+                        box.style[key] = values[key].get()
+                    }
+                }
+                renders.push(render)
+
+                for (const key of keys) {
+                    subscriptions.push(
+                        values[key].on("change", () => frame.render(render))
+                    )
+                }
+
+                render()
+                all.push(values)
+            }
+
+            return {
+                values: all,
+                cleanup() {
+                    for (const unsub of subscriptions) unsub()
+                    for (const render of renders) cancelFrame(render)
+                    for (const box of boxes) box.removeAttribute("style")
+                },
+            }
+        },
+    }
+
+    /** Granular per-value writes to element.style */
+    const style = {
+        name: "styleEffect (granular)",
+        bind(boxes, props) {
+            const all = []
+            const cleanups = []
+            for (const box of boxes) {
+                const values = makeValues(props)
+                cleanups.push(styleEffect(box, values))
+                all.push(values)
+            }
+            return {
+                values: all,
+                cleanup() {
+                    for (const cleanup of cleanups) cleanup()
+                    for (const box of boxes) box.removeAttribute("style")
+                },
+            }
+        },
+    }
+
+    /** Registered custom properties (inherits: false), written to inline style */
+    const varStrategy = {
+        name: "varEffect (registered vars)",
+        bind(boxes, props) {
+            const all = []
+            const cleanups = []
+            for (const box of boxes) {
+                const values = makeValues(props)
+                cleanups.push(varEffect(box, values))
+                all.push(values)
+            }
+            return {
+                values: all,
+                cleanup() {
+                    for (const cleanup of cleanups) cleanup()
+                    for (const box of boxes) box.removeAttribute("style")
+                },
+            }
+        },
+    }
+
+    /**
+     * Experimental: per-element rule in an adopted stylesheet. Values are
+     * written into the rule's declaration block, so the element's style
+     * attribute is never mutated after setup - this dodges [style*=...]
+     * attribute invalidation entirely (see style-recalc-harness).
+     */
+    let sheetId = 0
+    const sheet = {
+        name: "sheet (adopted stylesheet)",
+        bind(boxes, props) {
+            const all = []
+            const subscriptions = []
+            const renders = []
+            const styleSheet = new CSSStyleSheet()
+            const keys = Object.keys(props)
+
+            const src = []
+            const ids = []
+            for (let i = 0; i < boxes.length; i++) {
+                const id = sheetId++
+                ids.push(id)
+                boxes[i].setAttribute("data-mb", id)
+                src.push(`[data-mb="${id}"] {}`)
+            }
+            styleSheet.replaceSync(src.join("\n"))
+            document.adoptedStyleSheets = [
+                ...document.adoptedStyleSheets,
+                styleSheet,
+            ]
+
+            const dash = (key) =>
+                key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)
+
+            for (let i = 0; i < boxes.length; i++) {
+                const rule = styleSheet.cssRules[i]
+                const values = makeValues(props)
+
+                for (const key of keys) {
+                    const varName = `--mb${ids[i]}-${key}`
+                    try {
+                        CSS.registerProperty({
+                            name: varName,
+                            syntax: "*",
+                            inherits: false,
+                        })
+                    } catch (e) {}
+                    rule.style.setProperty(varName, values[key].get())
+                    rule.style.setProperty(dash(key), `var(${varName})`)
+
+                    const render = () => {
+                        rule.style.setProperty(varName, values[key].get())
+                    }
+                    renders.push(render)
+                    subscriptions.push(
+                        values[key].on("change", () => frame.render(render))
+                    )
+                }
+
+                all.push(values)
+            }
+
+            return {
+                values: all,
+                cleanup() {
+                    for (const unsub of subscriptions) unsub()
+                    for (const render of renders) cancelFrame(render)
+                    document.adoptedStyleSheets =
+                        document.adoptedStyleSheets.filter(
+                            (s) => s !== styleSheet
+                        )
+                    for (const box of boxes) box.removeAttribute("data-mb")
+                },
+            }
+        },
+    }
+
+    /**
+     * WAAPI (element.animate) on the main thread. Values are applied via
+     * the animation cascade origin, NOT the style attribute - so there is
+     * zero attribute mutation, before, during or after the animation.
+     * These paint properties are not compositable, so the animation still
+     * ticks on the main thread (style + paint per frame) like the others.
+     */
+    const waapi = {
+        name: "WAAPI (element.animate)",
+        bind(boxes) {
+            const binding = {
+                boxes,
+                animations: [],
+                cleanup() {
+                    for (const animation of binding.animations) {
+                        animation.cancel()
+                    }
+                    binding.animations = []
+                },
+            }
+            return binding
+        },
+        animate(binding, phaseProps, props, flip, duration) {
+            for (const animation of binding.animations) animation.cancel()
+            binding.animations = []
+
+            for (const box of binding.boxes) {
+                const keyframes = {}
+                for (const prop of phaseProps) {
+                    const [a, b] = props[prop]
+                    keyframes[prop] = flip ? [b, a] : [a, b]
+                }
+                binding.animations.push(
+                    box.animate(keyframes, {
+                        duration: duration * 1000,
+                        easing: "linear",
+                        fill: "forwards",
+                    })
+                )
+            }
+            return Promise.all(
+                binding.animations.map((animation) => animation.finished)
+            )
+        },
+    }
+
+    /**
+     * GSAP's JS renderer: its ticker writes inline styles every frame,
+     * so like legacy/styleEffect/varEffect it mutates the style attribute
+     * per frame and pays any attribute-selector invalidation cost.
+     */
+    const gsapStrategy = {
+        name: "GSAP (inline writes)",
+        bind(boxes, props) {
+            for (const box of boxes) {
+                for (const key in props) box.style[key] = props[key][0]
+            }
+            return {
+                boxes,
+                cleanup() {
+                    for (const box of boxes) {
+                        window.gsap.killTweensOf(box)
+                        box.removeAttribute("style")
+                    }
+                },
+            }
+        },
+        animate(binding, phaseProps, props, flip, duration) {
+            const tweens = []
+            for (const box of binding.boxes) {
+                /**
+                 * fromTo with explicit endpoints, matching the keyframe
+                 * semantics of the other strategies. A plain .to() would
+                 * create zero-change tweens for any property already at
+                 * its target (phases alternate direction), silently
+                 * animating fewer values than the other renderers.
+                 */
+                const fromVars = {}
+                const toVars = { duration, ease: "none", overwrite: "auto" }
+                for (const prop of phaseProps) {
+                    const [a, b] = props[prop]
+                    fromVars[prop] = flip ? b : a
+                    toVars[prop] = flip ? a : b
+                }
+                tweens.push(window.gsap.fromTo(box, fromVars, toVars))
+            }
+            return Promise.all(tweens)
+        },
+    }
+
+    return { legacy, style, var: varStrategy, sheet, waapi, gsap: gsapStrategy }
+}
+
+/** ------------------------------------------------------------------ */
+/** Metering                                                            */
+/** ------------------------------------------------------------------ */
+
+export function createFrameMeter(Motion) {
+    const { frame, cancelFrame } = Motion
+    let deltas = []
+    let renderMs = 0
+    let renderStart = 0
+    let rafId
+    let lastTs
+
+    const preRender = () => {
+        renderStart = performance.now()
+    }
+    const postRender = () => {
+        renderMs += performance.now() - renderStart
+    }
+
+    return {
+        start() {
+            deltas = []
+            renderMs = 0
+            lastTs = undefined
+            frame.preRender(preRender, true)
+            frame.postRender(postRender, true)
+            const tick = (ts) => {
+                if (lastTs !== undefined) deltas.push(ts - lastTs)
+                lastTs = ts
+                rafId = requestAnimationFrame(tick)
+            }
+            rafId = requestAnimationFrame(tick)
+        },
+        stop() {
+            cancelAnimationFrame(rafId)
+            cancelFrame(preRender)
+            cancelFrame(postRender)
+            const sorted = [...deltas].sort((a, b) => a - b)
+            const frames = deltas.length || 1
+            return {
+                frames: deltas.length,
+                mean: deltas.reduce((a, b) => a + b, 0) / frames,
+                p95: sorted[
+                    Math.min(sorted.length - 1, Math.floor(0.95 * frames))
+                ],
+                max: sorted[sorted.length - 1] ?? 0,
+                renderMsPerFrame: renderMs / frames,
+                fps: 1000 / (deltas.reduce((a, b) => a + b, 0) / frames),
+            }
+        },
+    }
+}
+
+/** ------------------------------------------------------------------ */
+/** Runner                                                              */
+/** ------------------------------------------------------------------ */
+
+/**
+ * Creates a benchmark driver. Phases are named prop subsets, e.g.
+ * { A: [all five], B: ["backgroundColor"] }. Exposes granular
+ * setup/runPhase/teardown for external (CDP) drivers, and runAll()
+ * implementing the standard protocol: per strategy, `runs` iterations
+ * of each phase without reload, first run discarded.
+ */
+export function createRunner({
+    Motion,
+    boxes,
+    strategies,
+    props,
+    phases,
+    duration = 2,
+    runs = 4,
+    onStatus = () => {},
+}) {
+    const { animate } = Motion
+    const meter = createFrameMeter(Motion)
+
+    let active = null
+    let direction = 0
+
+    async function setup(name) {
+        if (active) teardown()
+        direction = 0
+        const strategy = strategies[name]
+        active = { name, strategy, binding: strategy.bind(boxes, props) }
+        await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+
+    async function runPhase(phaseName) {
+        const phaseProps = phases[phaseName]
+        const flip = direction++ % 2 === 1
+
+        meter.start()
+        if (active.strategy.animate) {
+            /**
+             * Strategy drives its own animation (e.g. CSS transitions),
+             * bypassing Motion's main-thread animation loop entirely.
+             */
+            await active.strategy.animate(
+                active.binding,
+                phaseProps,
+                props,
+                flip,
+                duration
+            )
+        } else {
+            const animations = []
+            for (const values of active.binding.values) {
+                for (const prop of phaseProps) {
+                    const [a, b] = props[prop]
+                    animations.push(
+                        animate(values[prop], flip ? [b, a] : [a, b], {
+                            duration,
+                            ease: "linear",
+                        })
+                    )
+                }
+            }
+            await Promise.all(animations)
+        }
+        const stats = meter.stop()
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        return stats
+    }
+
+    function teardown() {
+        active?.binding.cleanup()
+        active = null
+    }
+
+    async function runAll(names) {
+        const results = []
+        for (const name of names) {
+            await setup(name)
+            const perPhase = {}
+            for (const phaseName in phases) perPhase[phaseName] = []
+
+            for (let r = 0; r < runs; r++) {
+                for (const phaseName in phases) {
+                    onStatus(
+                        `${strategies[name].name} — run ${
+                            r + 1
+                        }/${runs}, phase ${phaseName}`
+                    )
+                    perPhase[phaseName].push(await runPhase(phaseName))
+                }
+            }
+            teardown()
+
+            const summary = { name: strategies[name].name }
+            for (const phaseName in phases) {
+                /** Discard first run (JIT warmup) */
+                const warm = perPhase[phaseName].slice(1)
+                const avg = (key) =>
+                    warm.reduce((a, s) => a + s[key], 0) / warm.length
+                summary[phaseName] = {
+                    mean: avg("mean"),
+                    p95: avg("p95"),
+                    fps: avg("fps"),
+                    renderMsPerFrame: avg("renderMsPerFrame"),
+                    runs: perPhase[phaseName],
+                }
+            }
+            results.push(summary)
+        }
+        return results
+    }
+
+    return { setup, runPhase, teardown, runAll }
+}
+
+/** ------------------------------------------------------------------ */
+/** Reporting                                                           */
+/** ------------------------------------------------------------------ */
+
+export function renderResultsTable(el, results, phases) {
+    const phaseNames = Object.keys(phases)
+    let html = `<tr><th>renderer</th>`
+    for (const p of phaseNames) {
+        html += `<th>${p}: fps</th><th>${p}: mean frame (ms)</th><th>${p}: p95 (ms)</th><th>${p}: render JS (ms/frame)</th>`
+    }
+    html += `</tr>`
+    for (const r of results) {
+        html += `<tr><td>${r.name}</td>`
+        for (const p of phaseNames) {
+            html += `<td>${r[p].fps.toFixed(1)}</td><td>${r[p].mean.toFixed(
+                2
+            )}</td><td>${r[p].p95.toFixed(2)}</td><td>${r[
+                p
+            ].renderMsPerFrame.toFixed(3)}</td>`
+        }
+        html += `</tr>`
+    }
+    el.innerHTML = html
+}
+
+export const panelCSS = `
+    #panel {
+        position: fixed; top: 0; left: 0; right: 0;
+        background: rgba(0, 0, 0, 0.88); color: #fff;
+        padding: 10px 14px; z-index: 1000;
+        font-family: system-ui, sans-serif; font-size: 12px;
+        max-height: 40vh; overflow: auto;
+    }
+    #panel table { border-collapse: collapse; margin-top: 6px; }
+    #panel td, #panel th { border: 1px solid #555; padding: 2px 8px; text-align: right; }
+    #panel th:first-child, #panel td:first-child { text-align: left; }
+`

--- a/dev/html/public/benchmarks/renderer-test-1.html
+++ b/dev/html/public/benchmarks/renderer-test-1.html
@@ -1,0 +1,119 @@
+<html>
+    <!--
+      Renderer Test 1: Granularity
+
+      Animates five paint-triggering (non-layout) values on 300 elements
+      (phase A), then animates just one of those values (phase B). The
+      legacy VisualElement renderer re-applies all five styles whenever any
+      value changes, so phase B still writes five properties per element
+      per frame. styleEffect writes only the changed value. varEffect
+      writes only the changed value's registered custom property.
+
+      Protocol: per renderer, 4 runs without reload, first run discarded
+      (JIT warmup). Results are the average of runs 2-4.
+
+      Query params: boxes (default 300), duration (s, default 2), runs
+      (default 4), manual (expose window.__bench for external drivers).
+    -->
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+            #stage {
+                padding-top: 42vh;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 4px;
+            }
+            .box {
+                width: 40px;
+                height: 40px;
+                background: rgb(255, 40, 40);
+                border: 2px solid #333;
+                outline: 1px solid #666;
+                border-radius: 4px;
+                contain: layout;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="panel">
+            <div id="status">Loading…</div>
+            <table id="results"></table>
+        </div>
+        <div id="stage"></div>
+        <script type="module" src="/src/imports/framer-motion-dom.js"></script>
+        <script type="module" src="/src/imports/gsap.js"></script>
+        <script type="module">
+            import {
+                PAINT_PROPS,
+                buildBoxes,
+                createStrategies,
+                createRunner,
+                renderResultsTable,
+                panelCSS,
+            } from "./renderer-bench-lib.js"
+
+            const styleTag = document.createElement("style")
+            styleTag.textContent = panelCSS
+            document.head.appendChild(styleTag)
+
+            const q = new URLSearchParams(location.search)
+            const numBoxes = +(q.get("boxes") || 300)
+            const duration = +(q.get("duration") || 2)
+            const runs = +(q.get("runs") || 4)
+
+            const Motion = window.Motion
+            const status = document.getElementById("status")
+            const boxes = buildBoxes(document.getElementById("stage"), numBoxes)
+            const strategies = createStrategies(Motion)
+
+            const phases = {
+                "A (5 values)": Object.keys(PAINT_PROPS),
+                "B (1 value)": ["backgroundColor"],
+            }
+
+            const runner = createRunner({
+                Motion,
+                boxes,
+                strategies,
+                props: PAINT_PROPS,
+                phases,
+                duration,
+                runs,
+                onStatus: (message) => (status.textContent = message),
+            })
+
+            window.__bench = runner
+            window.__phases = phases
+
+            async function main() {
+                if (q.has("manual")) {
+                    status.textContent = `Ready (manual) — ${numBoxes} boxes`
+                    window.__done = true
+                    return
+                }
+
+                const results = await runner.runAll([
+                    "legacy",
+                    "style",
+                    "var",
+                    "gsap",
+                    "waapi",
+                ])
+                renderResultsTable(
+                    document.getElementById("results"),
+                    results,
+                    phases
+                )
+                status.textContent = `Done — ${numBoxes} boxes, ${runs} runs (first discarded), ${duration}s per phase`
+                window.__results = results
+                window.__done = true
+            }
+
+            main()
+        </script>
+    </body>
+</html>

--- a/dev/html/public/benchmarks/renderer-test-2.html
+++ b/dev/html/public/benchmarks/renderer-test-2.html
@@ -1,0 +1,212 @@
+<html>
+    <!--
+      Renderer Test 2: Hostile style-recalculation environment
+
+      Animates the same five paint-triggering values, but in an environment
+      where any inline style write triggers massive style recalculation:
+      the stylesheet contains [style*="..."] attribute selectors with
+      descendant combinators, and every animated element has descendants.
+      Writing to element.style (directly OR via style.setProperty for a
+      custom property) mutates the style attribute, which triggers
+      attribute invalidation and descends into subtrees.
+
+      Findings from style-recalc-harness.html: legacy, styleEffect AND
+      varEffect all pay this cost - registered custom properties don't
+      escape it because they still live on the style attribute. The
+      "sheet" strategy (adopted stylesheet per-element rule) never touches
+      the style attribute after setup and is immune.
+
+      The "css" strategy animates the same values with CSS transitions:
+      JS writes the target values once per run (one attribute mutation),
+      then the browser ticks the animation internally. Per-frame recalc is
+      ~1.4ms vs ~30-40ms for the per-frame inline writers, putting it on
+      par with the sheet strategy (both end up paint-bound).
+
+      The "waapi" strategy (element.animate) applies values via the
+      animation cascade origin - zero style-attribute mutation - and ties
+      with sheet/css at the top. The "gsap" strategy is GSAP's normal JS
+      renderer: per-frame inline writes, so it groups with legacy/
+      styleEffect (~40% slower than WAAPI here) despite winning nothing
+      in the benign test-1 environment either (all paint-bound there).
+
+      Protocol: per renderer, 4 runs without reload, first discarded.
+
+      Query params: boxes (default 100), descendants (default 50), rules
+      (default 1000), duration (s, default 2), runs (default 4), manual.
+    -->
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+            #stage {
+                padding-top: 42vh;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 4px;
+            }
+            .box {
+                width: 40px;
+                height: 40px;
+                background: rgb(255, 40, 40);
+                border: 2px solid #333;
+                outline: 1px solid #666;
+                border-radius: 4px;
+                overflow: hidden;
+                font-size: 4px;
+                line-height: 1;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="panel">
+            <div id="status">Loading…</div>
+            <table id="results"></table>
+        </div>
+        <div id="stage"></div>
+        <script type="module" src="/src/imports/framer-motion-dom.js"></script>
+        <script type="module" src="/src/imports/gsap.js"></script>
+        <script type="module">
+            import {
+                PAINT_PROPS,
+                buildBoxes,
+                createStrategies,
+                createRunner,
+                renderResultsTable,
+                panelCSS,
+            } from "./renderer-bench-lib.js"
+
+            const styleTag = document.createElement("style")
+            styleTag.textContent = panelCSS
+            document.head.appendChild(styleTag)
+
+            const q = new URLSearchParams(location.search)
+            const numBoxes = +(q.get("boxes") || 100)
+            const descendants = +(q.get("descendants") || 50)
+            const numRules = +(q.get("rules") || 1000)
+            const duration = +(q.get("duration") || 2)
+            const runs = +(q.get("runs") || 4)
+
+            /** Hostile environment: [style*] rules + descendant subtrees */
+            const frags = [
+                "rgb(",
+                "background",
+                "px",
+                "border",
+                "0 0",
+                "color",
+                "radius",
+                "shadow",
+                "outline",
+                ", 2",
+            ]
+            const rules = []
+            for (let i = 0; i < numRules; i++) {
+                rules.push(
+                    `.box[style*="${frags[i % frags.length]}"] .d${
+                        i % 10
+                    } { z-index: ${i}; }`
+                )
+            }
+            const hostileSheet = document.createElement("style")
+            hostileSheet.textContent = rules.join("\n")
+            document.head.appendChild(hostileSheet)
+
+            const Motion = window.Motion
+            const status = document.getElementById("status")
+            const boxes = buildBoxes(
+                document.getElementById("stage"),
+                numBoxes,
+                descendants
+            )
+            const strategies = createStrategies(Motion)
+
+            /**
+             * CSS transitions: JS writes each target value once per run
+             * (one style-attribute mutation per element), then the browser
+             * ticks the animation internally. Per-frame there are no
+             * attribute mutations, so [style*=] invalidation is paid once
+             * per run rather than every frame.
+             */
+            strategies.css = {
+                name: "CSS transition",
+                bind(boxes, props) {
+                    for (const box of boxes) {
+                        for (const key in props) box.style[key] = props[key][0]
+                    }
+                    /** Flush initial values before enabling transitions */
+                    void boxes[0].offsetWidth
+                    for (const box of boxes) {
+                        box.style.transition = `all ${duration}s linear`
+                    }
+                    return {
+                        boxes,
+                        cleanup() {
+                            for (const box of boxes) {
+                                box.removeAttribute("style")
+                            }
+                        },
+                    }
+                },
+                animate(binding, phaseProps, props, flip, duration) {
+                    for (const box of binding.boxes) {
+                        for (const prop of phaseProps) {
+                            const [a, b] = props[prop]
+                            box.style[prop] = flip ? a : b
+                        }
+                    }
+                    return new Promise((resolve) =>
+                        setTimeout(resolve, duration * 1000 + 50)
+                    )
+                },
+            }
+
+            const phases = {
+                "5 values": Object.keys(PAINT_PROPS),
+            }
+
+            const runner = createRunner({
+                Motion,
+                boxes,
+                strategies,
+                props: PAINT_PROPS,
+                phases,
+                duration,
+                runs,
+                onStatus: (message) => (status.textContent = message),
+            })
+
+            window.__bench = runner
+            window.__phases = phases
+
+            async function main() {
+                if (q.has("manual")) {
+                    status.textContent = `Ready (manual) — ${numBoxes} boxes × ${descendants} descendants, ${numRules} [style*] rules`
+                    window.__done = true
+                    return
+                }
+
+                const results = await runner.runAll([
+                    "legacy",
+                    "style",
+                    "var",
+                    "sheet",
+                    "css",
+                    "gsap",
+                    "waapi",
+                ])
+                renderResultsTable(
+                    document.getElementById("results"),
+                    results,
+                    phases
+                )
+                status.textContent = `Done — ${numBoxes} boxes × ${descendants} descendants, ${numRules} [style*] rules, ${runs} runs (first discarded)`
+                window.__results = results
+                window.__done = true
+            }
+
+            main()
+        </script>
+    </body>
+</html>

--- a/dev/html/public/benchmarks/renderer-test-3.html
+++ b/dev/html/public/benchmarks/renderer-test-3.html
@@ -1,0 +1,268 @@
+<html>
+    <!--
+      Renderer Test 3: Transform threshold - paint vs style recalculation
+
+      Animates x/y/scale/rotate (composed into a single transform) and
+      compares, across renderers:
+
+        - style:     styleEffect, inline transform, no will-change
+                     (style recalc + paint every frame)
+        - style-wc:  styleEffect + will-change: transform
+                     (style recalc, composited - no paint)
+        - var:       varEffect, transform via registered custom property
+        - var-wc:    varEffect + will-change: transform
+        - sheet:     transform composed into an adopted stylesheet rule
+                     (no style attribute mutation)
+        - sheet-wc:  sheet + will-change: transform (set inside the rule)
+
+      Run with env=hostile (default) to add [style*] rules + descendants,
+      making inline style writes trigger massive recalculation. Sweep
+      ?boxes= and ?boxSize= to find the threshold where paint cost
+      (larger/more elements, no will-change) overtakes recalc cost.
+
+      Protocol: per mode, 4 runs without reload, first discarded.
+
+      Query params: boxes (default 300), boxSize (px, default 60),
+      env (hostile | plain), descendants (default 30), rules (default
+      1000), duration (default 2), runs (default 4), manual.
+    -->
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+            #stage {
+                padding-top: 42vh;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+            .box {
+                background: rgb(255, 40, 40);
+                border: 2px solid #333;
+                border-radius: 4px;
+                overflow: hidden;
+                font-size: 4px;
+                line-height: 1;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="panel">
+            <div id="status">Loading…</div>
+            <table id="results"></table>
+        </div>
+        <div id="stage"></div>
+        <script type="module" src="/src/imports/framer-motion-dom.js"></script>
+        <script type="module">
+            import {
+                buildBoxes,
+                createStrategies,
+                createRunner,
+                renderResultsTable,
+                panelCSS,
+            } from "./renderer-bench-lib.js"
+
+            const styleTag = document.createElement("style")
+            styleTag.textContent = panelCSS
+            document.head.appendChild(styleTag)
+
+            const q = new URLSearchParams(location.search)
+            const numBoxes = +(q.get("boxes") || 300)
+            const boxSize = +(q.get("boxSize") || 60)
+            const env = q.get("env") || "hostile"
+            const descendants = +(q.get("descendants") || 30)
+            const numRules = +(q.get("rules") || 1000)
+            const duration = +(q.get("duration") || 2)
+            const runs = +(q.get("runs") || 4)
+
+            const sizeSheet = document.createElement("style")
+            sizeSheet.textContent = `.box { width: ${boxSize}px; height: ${boxSize}px; }`
+            document.head.appendChild(sizeSheet)
+
+            if (env === "hostile") {
+                const frags = ["rgb(", "translate", "px", "scale(", "rotate"]
+                const rules = []
+                for (let i = 0; i < numRules; i++) {
+                    rules.push(
+                        `.box[style*="${frags[i % frags.length]}"] .d${
+                            i % 10
+                        } { z-index: ${i}; }`
+                    )
+                }
+                const hostileSheet = document.createElement("style")
+                hostileSheet.textContent = rules.join("\n")
+                document.head.appendChild(hostileSheet)
+            }
+
+            const TRANSFORM_PROPS = {
+                x: [0, 60],
+                y: [0, 40],
+                scale: [1, 1.15],
+                rotate: [0, 45],
+            }
+
+            const Motion = window.Motion
+            const { motionValue, frame, cancelFrame } = Motion
+            const status = document.getElementById("status")
+            const boxes = buildBoxes(
+                document.getElementById("stage"),
+                numBoxes,
+                env === "hostile" ? descendants : 0
+            )
+            const base = createStrategies(Motion)
+
+            /**
+             * Transform composed into a registered var inside an adopted
+             * stylesheet rule - element attributes never mutated per frame.
+             */
+            let sheetTransformId = 0
+            const makeSheetTransform = (willChange) => ({
+                name: `sheet transform${willChange ? " + will-change" : ""}`,
+                bind(targets, props) {
+                    const all = []
+                    const subscriptions = []
+                    const renders = []
+                    const styleSheet = new CSSStyleSheet()
+
+                    const src = []
+                    const ids = []
+                    for (let i = 0; i < targets.length; i++) {
+                        const id = sheetTransformId++
+                        ids.push(id)
+                        targets[i].setAttribute("data-mt", id)
+                        src.push(`[data-mt="${id}"] {}`)
+                    }
+                    styleSheet.replaceSync(src.join("\n"))
+                    document.adoptedStyleSheets = [
+                        ...document.adoptedStyleSheets,
+                        styleSheet,
+                    ]
+
+                    for (let i = 0; i < targets.length; i++) {
+                        const rule = styleSheet.cssRules[i]
+                        const varName = `--mt${ids[i]}`
+                        try {
+                            CSS.registerProperty({
+                                name: varName,
+                                syntax: "*",
+                                inherits: false,
+                            })
+                        } catch (e) {}
+
+                        const values = {}
+                        for (const prop in props) {
+                            values[prop] = motionValue(props[prop][0])
+                        }
+
+                        const render = () => {
+                            rule.style.setProperty(
+                                varName,
+                                `translateX(${values.x.get()}px) translateY(${values.y.get()}px) scale(${values.scale.get()}) rotate(${values.rotate.get()}deg)`
+                            )
+                        }
+                        renders.push(render)
+                        render()
+                        rule.style.setProperty("transform", `var(${varName})`)
+                        if (willChange) {
+                            rule.style.setProperty("will-change", "transform")
+                        }
+
+                        for (const prop in props) {
+                            subscriptions.push(
+                                values[prop].on("change", () =>
+                                    frame.render(render)
+                                )
+                            )
+                        }
+
+                        all.push(values)
+                    }
+
+                    return {
+                        values: all,
+                        cleanup() {
+                            for (const unsub of subscriptions) unsub()
+                            for (const render of renders) cancelFrame(render)
+                            document.adoptedStyleSheets =
+                                document.adoptedStyleSheets.filter(
+                                    (s) => s !== styleSheet
+                                )
+                            for (const target of targets) {
+                                target.removeAttribute("data-mt")
+                            }
+                        },
+                    }
+                },
+            })
+
+            /** Wrap a strategy to apply inline will-change at bind time */
+            const withWillChange = (strategy) => ({
+                name: `${strategy.name} + will-change`,
+                bind(targets, props) {
+                    for (const target of targets) {
+                        target.style.willChange = "transform"
+                    }
+                    const binding = strategy.bind(targets, props)
+                    return {
+                        values: binding.values,
+                        cleanup() {
+                            binding.cleanup()
+                            for (const target of targets) {
+                                target.style.willChange = ""
+                            }
+                        },
+                    }
+                },
+            })
+
+            const strategies = {
+                style: base.style,
+                "style-wc": withWillChange(base.style),
+                var: base.var,
+                "var-wc": withWillChange(base.var),
+                sheet: makeSheetTransform(false),
+                "sheet-wc": makeSheetTransform(true),
+            }
+
+            const phases = {
+                transform: Object.keys(TRANSFORM_PROPS),
+            }
+
+            const runner = createRunner({
+                Motion,
+                boxes,
+                strategies,
+                props: TRANSFORM_PROPS,
+                phases,
+                duration,
+                runs,
+                onStatus: (message) => (status.textContent = message),
+            })
+
+            window.__bench = runner
+            window.__phases = phases
+
+            async function main() {
+                if (q.has("manual")) {
+                    status.textContent = `Ready (manual) — ${numBoxes} boxes @ ${boxSize}px, env: ${env}`
+                    window.__done = true
+                    return
+                }
+
+                const results = await runner.runAll(Object.keys(strategies))
+                renderResultsTable(
+                    document.getElementById("results"),
+                    results,
+                    phases
+                )
+                status.textContent = `Done — ${numBoxes} boxes @ ${boxSize}px, env: ${env}, ${runs} runs (first discarded)`
+                window.__results = results
+                window.__done = true
+            }
+
+            main()
+        </script>
+    </body>
+</html>

--- a/dev/html/public/benchmarks/style-recalc-harness.html
+++ b/dev/html/public/benchmarks/style-recalc-harness.html
@@ -1,0 +1,736 @@
+<html>
+    <!--
+      Style Recalc Harness
+
+      Step 1 of the CSS.registerProperty renderer investigation. Finds
+      environments where per-frame writes to element.style trigger large
+      style recalculations, and whether writing to a registered CSS custom
+      property (inherits: false) avoids them.
+
+      Modes (how values are written each frame):
+        - direct:           element.style[prop] = value
+        - var-unregistered: element.style.setProperty("--id", value), prop set once to var(--id)
+        - var-registered:   as above, but CSS.registerProperty({ inherits: false })
+        - var-inherits:     as above, but CSS.registerProperty({ inherits: true })
+
+      Environments (what makes recalc expensive):
+        - plain:       flat boxes, minimal CSS
+        - descendants: each box has N descendants
+        - bigsheet:    huge stylesheet of complex selectors targeting boxes/descendants
+        - attr-style:  stylesheet full of [style*="..."] selectors + descendants
+        - has:         :has() rules keyed off box style attributes
+        - has-class:   :has() rules keyed off classes (NOT [style]) - negative control
+        - siblings:    boxes share a parent with many siblings + [style] ~ sibling rules
+        - container:   @container style(--p: ...) queries in descendants; use with
+                       props=custom so writers animate --p (add &reg to register
+                       --p with inherits: false)
+        - transitions: transition: all on boxes + descendants (retarget every frame)
+
+      Query params:
+        mode, env, props (paint | inherited | layout | custom), boxes,
+        descendants, rules, frames (per run), runs (first is discarded),
+        auto (run all modes), flush (force + time a synchronous style flush
+        after each write batch - measures invalidation cost independently
+        of the vsync frame budget, which otherwise hides any cost that
+        fits inside 16.67ms)
+
+      Example:
+        style-recalc-harness.html?env=descendants&auto
+    -->
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+                font-family: system-ui, sans-serif;
+                font-size: 12px;
+            }
+            #panel {
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                background: rgba(0, 0, 0, 0.85);
+                color: #fff;
+                padding: 10px 14px;
+                z-index: 1000;
+                max-height: 45vh;
+                overflow: auto;
+            }
+            #panel table {
+                border-collapse: collapse;
+                margin-top: 6px;
+            }
+            #panel td,
+            #panel th {
+                border: 1px solid #555;
+                padding: 2px 8px;
+                text-align: right;
+            }
+            #panel th:first-child,
+            #panel td:first-child {
+                text-align: left;
+            }
+            #stage {
+                padding-top: 46vh;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 4px;
+            }
+            .box {
+                width: 40px;
+                height: 40px;
+                background: #e33;
+                border: 2px solid #333;
+                outline: 1px solid #666;
+                border-radius: 4px;
+                overflow: hidden;
+                font-size: 4px;
+                line-height: 1;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="panel">
+            <div id="status">Loading…</div>
+            <table id="results"></table>
+        </div>
+        <div id="stage"></div>
+
+        <script type="module">
+            const q = new URLSearchParams(location.search)
+            const cfg = {
+                mode: q.get("mode") || "direct",
+                env: q.get("env") || "plain",
+                props: q.get("props") || "paint",
+                boxes: +(q.get("boxes") || 100),
+                descendants: +(q.get("descendants") || 100),
+                rules: +(q.get("rules") || 20000),
+                frames: +(q.get("frames") || 150),
+                runs: +(q.get("runs") || 4),
+                auto: q.has("auto"),
+                flush: q.has("flush"),
+            }
+
+            const ALL_MODES = [
+                "direct",
+                "var-unregistered",
+                "var-registered",
+                "var-inherits",
+                "sheet-direct",
+                "sheet-var-registered",
+            ]
+
+            const PROP_SETS = {
+                paint: [
+                    "backgroundColor",
+                    "borderColor",
+                    "borderRadius",
+                    "boxShadow",
+                    "outlineColor",
+                ],
+                inherited: ["color"],
+                layout: ["width"],
+                custom: ["--p"],
+            }
+
+            const CSS_NAMES = {
+                backgroundColor: "background-color",
+                borderColor: "border-color",
+                borderRadius: "border-radius",
+                boxShadow: "box-shadow",
+                outlineColor: "outline-color",
+                color: "color",
+                width: "width",
+                "--p": "--p",
+            }
+
+            const props = PROP_SETS[cfg.props]
+            const status = document.getElementById("status")
+            const stage = document.getElementById("stage")
+
+            /**
+             * Precompute per-frame value strings so per-frame JS cost is
+             * identical across modes - we only want to measure style recalc.
+             */
+            const CYCLE = 360
+            const frameValues = {}
+            for (const prop of props) frameValues[prop] = []
+            for (let f = 0; f < CYCLE; f++) {
+                const r = (f * 17) % 256
+                const g = (f * 89) % 256
+                const b = (f * 251) % 256
+                for (const prop of props) {
+                    let v
+                    switch (prop) {
+                        case "backgroundColor":
+                        case "color":
+                            v = `rgb(${r}, ${g}, ${b})`
+                            break
+                        case "borderColor":
+                            v = `rgb(${b}, ${r}, ${g})`
+                            break
+                        case "outlineColor":
+                            v = `rgb(${g}, ${b}, ${r})`
+                            break
+                        case "borderRadius":
+                            v = `${4 + (f % 16)}px`
+                            break
+                        case "boxShadow":
+                            v = `0 0 ${2 + (f % 10)}px rgb(${r}, ${g}, ${b})`
+                            break
+                        case "width":
+                            v = `${40 + (f % 20)}px`
+                            break
+                        case "--p":
+                            v = `${(f * 7) % 200}px`
+                            break
+                    }
+                    frameValues[prop].push(v)
+                }
+            }
+
+            /** ---------------------------------------------------------- */
+            /** Environment construction                                    */
+            /** ---------------------------------------------------------- */
+
+            function buildEnvironment() {
+                const styles = []
+                let boxDescendants = 0
+                let siblingCount = 0
+                let useCards = false
+
+                switch (cfg.env) {
+                    case "plain":
+                        break
+
+                    case "descendants":
+                        boxDescendants = cfg.descendants
+                        break
+
+                    case "bigsheet": {
+                        boxDescendants = Math.min(cfg.descendants, 20)
+                        for (let i = 0; i < cfg.rules; i++) {
+                            const a = i % 40
+                            const b = i % 23
+                            const n = (i % 11) + 2
+                            if (i % 2) {
+                                styles.push(
+                                    `.w${a} .x${b} > .box:nth-of-type(${n}n+1) { z-index: ${i}; }`
+                                )
+                            } else {
+                                styles.push(
+                                    `.w${a} > .x${b} .box .d${i % 10} { z-index: ${i}; }`
+                                )
+                            }
+                        }
+                        break
+                    }
+
+                    case "attr-style": {
+                        boxDescendants = cfg.descendants
+                        const frags = [
+                            "rgb(",
+                            "background",
+                            "px",
+                            "border",
+                            "0 0",
+                            "color",
+                            "radius",
+                            "shadow",
+                            "outline",
+                            ", 2",
+                        ]
+                        const ruleCount = Math.min(cfg.rules, 2000)
+                        for (let i = 0; i < ruleCount; i++) {
+                            styles.push(
+                                `.box[style*="${frags[i % frags.length]}"] .d${
+                                    i % 10
+                                } { z-index: ${i}; }`
+                            )
+                        }
+                        break
+                    }
+
+                    case "has": {
+                        useCards = true
+                        boxDescendants = 0
+                        const frags = ["rgb(", "background", "px", "border"]
+                        for (let i = 0; i < 400; i++) {
+                            styles.push(
+                                `.card:has(.box[style*="${
+                                    frags[i % frags.length]
+                                }"]) .payload .p${i % 10} { z-index: ${i}; }`
+                            )
+                        }
+                        break
+                    }
+
+                    case "siblings": {
+                        siblingCount = 3000
+                        for (let i = 0; i < 500; i++) {
+                            styles.push(
+                                `.box[style] ~ .sib${i % 10} { z-index: ${i}; }`
+                            )
+                        }
+                        break
+                    }
+
+                    /**
+                     * Negative control for :has(): rules keyed off classes
+                     * rather than the style attribute. If Blink's :has
+                     * invalidation is precise, per-frame style writes should
+                     * NOT re-evaluate these.
+                     */
+                    case "has-class": {
+                        useCards = true
+                        for (let i = 0; i < 400; i++) {
+                            styles.push(
+                                `.card:has(.box.active${i % 5}) .payload .p${
+                                    i % 10
+                                } { z-index: ${i}; }`
+                            )
+                        }
+                        break
+                    }
+
+                    /**
+                     * Style container queries. Every element is a style
+                     * query container by default, so descendants keyed on
+                     * style(--p: ...) subscribe to the box's computed
+                     * custom properties. Use with props=custom so the
+                     * writers animate --p itself.
+                     */
+                    case "container": {
+                        boxDescendants = cfg.descendants
+                        if (q.has("reg")) {
+                            try {
+                                CSS.registerProperty({
+                                    name: "--p",
+                                    syntax: "*",
+                                    inherits: false,
+                                })
+                            } catch (e) {}
+                        }
+                        for (let i = 0; i < 200; i++) {
+                            styles.push(
+                                `@container style(--p: ${i}px) { .d${
+                                    i % 10
+                                } { z-index: ${i}; } }`
+                            )
+                        }
+                        break
+                    }
+
+                    /**
+                     * transition: all on the animated elements - every
+                     * style write forces before/after style diffing and
+                     * transition retargeting. Common in the wild via
+                     * `* { transition: all ... }` reset habits.
+                     */
+                    case "transitions": {
+                        boxDescendants = Math.min(cfg.descendants, 10)
+                        styles.push(
+                            `.box, .box span { transition: all 0.05s linear; }`
+                        )
+                        break
+                    }
+
+                    /**
+                     * Same as transitions, but with named properties
+                     * covering exactly the animated set - isolates the
+                     * cost of the `all` keyword vs transition retargeting
+                     * itself.
+                     */
+                    case "transitions-named": {
+                        boxDescendants = Math.min(cfg.descendants, 10)
+                        styles.push(
+                            `.box, .box span { transition: background-color 0.05s linear, border-color 0.05s linear, border-radius 0.05s linear, box-shadow 0.05s linear, outline-color 0.05s linear; }`
+                        )
+                        break
+                    }
+                }
+
+                if (styles.length) {
+                    const sheet = document.createElement("style")
+                    sheet.textContent = styles.join("\n")
+                    document.head.appendChild(sheet)
+                }
+
+                /** Build DOM */
+                const parts = []
+                const descendantHtml = () => {
+                    let d = ""
+                    for (let j = 0; j < boxDescendants; j++) {
+                        d += `<span class="d${j % 10}">x</span>`
+                    }
+                    return d
+                }
+
+                for (let i = 0; i < cfg.boxes; i++) {
+                    const box = `<div class="box">${descendantHtml()}</div>`
+                    if (useCards) {
+                        let payload = ""
+                        for (let j = 0; j < cfg.descendants; j++) {
+                            payload += `<span class="p${j % 10}">x</span>`
+                        }
+                        parts.push(
+                            `<div class="card">${box}<div class="payload">${payload}</div></div>`
+                        )
+                    } else if (cfg.env === "bigsheet") {
+                        parts.push(
+                            `<div class="w${i % 40}"><div class="x${
+                                i % 23
+                            }">${box}</div></div>`
+                        )
+                    } else {
+                        parts.push(box)
+                    }
+                }
+
+                for (let i = 0; i < siblingCount; i++) {
+                    parts.push(`<div class="sib${i % 10}">s</div>`)
+                }
+
+                stage.innerHTML = parts.join("")
+                return Array.from(stage.querySelectorAll(".box"))
+            }
+
+            /** ---------------------------------------------------------- */
+            /** Write strategies                                            */
+            /** ---------------------------------------------------------- */
+
+            let varGeneration = 0
+
+            function createWriter(mode, boxes) {
+                if (mode === "direct") {
+                    return {
+                        setup() {},
+                        writeFrame(f) {
+                            for (const box of boxes) {
+                                for (const prop of props) {
+                                    if (prop.startsWith("--")) {
+                                        box.style.setProperty(
+                                            prop,
+                                            frameValues[prop][f % CYCLE]
+                                        )
+                                    } else {
+                                        box.style[prop] =
+                                            frameValues[prop][f % CYCLE]
+                                    }
+                                }
+                            }
+                        },
+                        teardown() {
+                            for (const box of boxes) {
+                                box.removeAttribute("style")
+                            }
+                        },
+                    }
+                }
+
+                /**
+                 * Stylesheet modes: values are written into a per-element
+                 * rule in an adopted stylesheet, so the element's style
+                 * attribute is never touched after setup.
+                 */
+                if (mode.startsWith("sheet")) {
+                    const useVars = mode === "sheet-var-registered"
+                    const gen = varGeneration++
+                    const sheet = new CSSStyleSheet()
+                    /** rules[boxIndex] = CSSStyleRule */
+                    const rules = []
+
+                    return {
+                        setup() {
+                            const src = []
+                            for (let i = 0; i < boxes.length; i++) {
+                                boxes[i].setAttribute("data-m", `${gen}-${i}`)
+                                src.push(`[data-m="${gen}-${i}"] {}`)
+                            }
+                            sheet.replaceSync(src.join("\n"))
+                            document.adoptedStyleSheets = [
+                                ...document.adoptedStyleSheets,
+                                sheet,
+                            ]
+                            for (let i = 0; i < boxes.length; i++) {
+                                rules.push(sheet.cssRules[i])
+                                for (let p = 0; p < props.length; p++) {
+                                    if (useVars) {
+                                        const name = `--m${gen}-${i}-${p}`
+                                        try {
+                                            CSS.registerProperty({
+                                                name,
+                                                syntax: "*",
+                                                inherits: false,
+                                            })
+                                        } catch (e) {}
+                                        rules[i].style.setProperty(
+                                            name,
+                                            frameValues[props[p]][0]
+                                        )
+                                        rules[i].style.setProperty(
+                                            CSS_NAMES[props[p]],
+                                            `var(${name})`
+                                        )
+                                    }
+                                }
+                            }
+                        },
+                        writeFrame(f) {
+                            for (let i = 0; i < boxes.length; i++) {
+                                for (let p = 0; p < props.length; p++) {
+                                    if (useVars) {
+                                        rules[i].style.setProperty(
+                                            `--m${gen}-${i}-${p}`,
+                                            frameValues[props[p]][f % CYCLE]
+                                        )
+                                    } else if (props[p].startsWith("--")) {
+                                        rules[i].style.setProperty(
+                                            props[p],
+                                            frameValues[props[p]][f % CYCLE]
+                                        )
+                                    } else {
+                                        rules[i].style[props[p]] =
+                                            frameValues[props[p]][f % CYCLE]
+                                    }
+                                }
+                            }
+                        },
+                        teardown() {
+                            document.adoptedStyleSheets =
+                                document.adoptedStyleSheets.filter(
+                                    (s) => s !== sheet
+                                )
+                            for (const box of boxes) {
+                                box.removeAttribute("data-m")
+                            }
+                        },
+                    }
+                }
+
+                /** var modes */
+                const register = mode !== "var-unregistered"
+                const inherits = mode === "var-inherits"
+                const gen = varGeneration++
+                /** varNames[boxIndex][propIndex] */
+                const varNames = []
+
+                return {
+                    setup() {
+                        for (let i = 0; i < boxes.length; i++) {
+                            const names = []
+                            for (let p = 0; p < props.length; p++) {
+                                const name = `--m${gen}-${i}-${p}`
+                                if (register) {
+                                    try {
+                                        CSS.registerProperty({
+                                            name,
+                                            syntax: "*",
+                                            inherits,
+                                        })
+                                    } catch (e) {}
+                                }
+                                boxes[i].style.setProperty(
+                                    name,
+                                    frameValues[props[p]][0]
+                                )
+                                boxes[i].style.setProperty(
+                                    CSS_NAMES[props[p]],
+                                    `var(${name})`
+                                )
+                                names.push(name)
+                            }
+                            varNames.push(names)
+                        }
+                    },
+                    writeFrame(f) {
+                        for (let i = 0; i < boxes.length; i++) {
+                            const names = varNames[i]
+                            for (let p = 0; p < props.length; p++) {
+                                boxes[i].style.setProperty(
+                                    names[p],
+                                    frameValues[props[p]][f % CYCLE]
+                                )
+                            }
+                        }
+                    },
+                    teardown() {
+                        for (const box of boxes) {
+                            box.removeAttribute("style")
+                        }
+                    },
+                }
+            }
+
+            /** ---------------------------------------------------------- */
+            /** Measurement                                                 */
+            /** ---------------------------------------------------------- */
+
+            /**
+             * Long Animation Frames give us style+layout duration
+             * attribution where supported (Chrome 123+).
+             */
+            let loafStyleMs = 0
+            let loafObserver
+            try {
+                loafObserver = new PerformanceObserver((list) => {
+                    for (const entry of list.getEntries()) {
+                        const end = entry.startTime + entry.duration
+                        if (entry.styleAndLayoutStart > 0) {
+                            loafStyleMs += end - entry.styleAndLayoutStart
+                        }
+                    }
+                })
+                loafObserver.observe({ type: "long-animation-frame" })
+            } catch (e) {}
+
+            function percentile(sorted, p) {
+                const i = Math.min(
+                    sorted.length - 1,
+                    Math.floor((p / 100) * sorted.length)
+                )
+                return sorted[i]
+            }
+
+            function runOnce(writer) {
+                return new Promise((resolve) => {
+                    const deltas = []
+                    let frameIndex = 0
+                    let lastTs
+                    let flushMs = 0
+                    const loafStart = loafStyleMs
+
+                    function tick(ts) {
+                        if (lastTs !== undefined) deltas.push(ts - lastTs)
+                        lastTs = ts
+
+                        if (frameIndex >= cfg.frames) {
+                            const sorted = [...deltas].sort((a, b) => a - b)
+                            resolve({
+                                frames: deltas.length,
+                                mean:
+                                    deltas.reduce((a, b) => a + b, 0) /
+                                    deltas.length,
+                                p95: percentile(sorted, 95),
+                                max: sorted[sorted.length - 1],
+                                loafStyleMs: loafStyleMs - loafStart,
+                                flushMs: flushMs / cfg.frames,
+                            })
+                            return
+                        }
+
+                        writer.writeFrame(frameIndex)
+                        if (cfg.flush) {
+                            /**
+                             * Force the style/layout flush synchronously and
+                             * time it, so invalidation cost is visible even
+                             * when it fits inside the vsync frame budget.
+                             */
+                            const t0 = performance.now()
+                            void document.body.offsetWidth
+                            flushMs += performance.now() - t0
+                        }
+                        frameIndex++
+                        requestAnimationFrame(tick)
+                    }
+
+                    requestAnimationFrame(tick)
+                })
+            }
+
+            async function runMode(mode, boxes) {
+                const writer = createWriter(mode, boxes)
+                const setupStart = performance.now()
+                writer.setup()
+                const setupMs = performance.now() - setupStart
+
+                const runs = []
+                for (let r = 0; r < cfg.runs; r++) {
+                    status.textContent = `Running ${mode} — run ${r + 1}/${
+                        cfg.runs
+                    } (env: ${cfg.env}, props: ${cfg.props}, boxes: ${
+                        cfg.boxes
+                    })`
+                    /** Let the previous run's rendering settle */
+                    await new Promise((res) => setTimeout(res, 100))
+                    runs.push(await runOnce(writer))
+                }
+                writer.teardown()
+
+                /** Discard first run (JIT warmup) */
+                const warm = runs.slice(1)
+                const avg = (key) =>
+                    warm.reduce((a, r) => a + r[key], 0) / warm.length
+
+                return {
+                    mode,
+                    setupMs,
+                    runs,
+                    mean: avg("mean"),
+                    p95: avg("p95"),
+                    max: avg("max"),
+                    loafStyleMs: avg("loafStyleMs"),
+                    flushMs: avg("flushMs"),
+                }
+            }
+
+            /** ---------------------------------------------------------- */
+            /** Reporting                                                   */
+            /** ---------------------------------------------------------- */
+
+            const resultsTable = document.getElementById("results")
+
+            function renderResults(all) {
+                let html = `<tr><th>mode</th><th>mean frame (ms)</th><th>p95 (ms)</th><th>max (ms)</th><th>flush style (ms/frame)</th><th>style+layout / run (ms)</th><th>setup (ms)</th></tr>`
+                for (const r of all) {
+                    html += `<tr><td>${r.mode}</td><td>${r.mean.toFixed(
+                        2
+                    )}</td><td>${r.p95.toFixed(2)}</td><td>${r.max.toFixed(
+                        2
+                    )}</td><td>${r.flushMs.toFixed(
+                        3
+                    )}</td><td>${r.loafStyleMs.toFixed(
+                        1
+                    )}</td><td>${r.setupMs.toFixed(1)}</td></tr>`
+                }
+                resultsTable.innerHTML = html
+            }
+
+            async function main() {
+                const boxes = buildEnvironment()
+                const all = []
+
+                /**
+                 * Manual driver for automation (e.g. CDP): navigate with
+                 * ?manual, then await window.__runMode("direct") etc to get
+                 * clean per-mode metric deltas without reloads.
+                 */
+                window.__runMode = async (mode) => {
+                    const result = await runMode(mode, boxes)
+                    all.push(result)
+                    renderResults(all)
+                    window.__results = { cfg, results: all }
+                    return result
+                }
+
+                if (q.has("manual")) {
+                    status.textContent = `Ready (manual) — env: ${cfg.env}, props: ${cfg.props}, boxes: ${cfg.boxes}, descendants/box: ${cfg.descendants}`
+                    window.__done = true
+                    return
+                }
+
+                const modes = cfg.auto ? ALL_MODES : [cfg.mode]
+
+                for (const mode of modes) {
+                    await window.__runMode(mode)
+                }
+
+                status.textContent = `Done — env: ${cfg.env}, props: ${cfg.props}, boxes: ${cfg.boxes}, descendants/box: ${cfg.descendants}, frames/run: ${cfg.frames}, runs: ${cfg.runs} (first discarded)`
+                window.__done = true
+            }
+
+            main()
+        </script>
+    </body>
+</html>

--- a/dev/react/profile-layout.mjs
+++ b/dev/react/profile-layout.mjs
@@ -1,0 +1,142 @@
+/**
+ * Profiles a layout-animation stress example.
+ *
+ * Loads dev/react at ?example=<name>, starts Motion's recordStats() plus the
+ * V8 sampling profiler, clicks to trigger the layout animation, then reports:
+ * - frame rate + projection metrics (from recordStats)
+ * - total sampled JS ms and per-frame JS ms
+ * - self-time hotspots grouped by function
+ * - time attributed to projection source vs everything else
+ *
+ * Usage: node profile-layout.mjs [example] [profileMs] [port]
+ *   e.g. node profile-layout.mjs layout-stress 4000 9990
+ */
+import { chromium } from "playwright"
+import { writeFileSync } from "fs"
+
+const example = process.argv[2] || "layout-stress"
+const profileMs = +(process.argv[3] || 4000)
+const port = +(process.argv[4] || 9990)
+/** ms to wait after the click before profiling (skips the didUpdate burst) */
+const skipMs = process.argv[5] === undefined ? 600 : +process.argv[5]
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1400, height: 1000 } })
+await page.goto(`http://localhost:${port}/?example=${example}`)
+await page.waitForFunction(() => typeof window.recordStats === "function")
+/** Let the initial mount settle */
+await page.waitForTimeout(500)
+
+const client = await page.context().newCDPSession(page)
+await client.send("Profiler.enable")
+await client.send("Profiler.setSamplingInterval", { interval: 100 })
+
+/**
+ * recordStats() returns a report function on newer builds. On older
+ * builds it returns undefined - stats are then omitted from the output
+ * and only the V8 profile is reported.
+ */
+const startStats = () =>
+    page.evaluate(() => {
+        window.__report = window.recordStats()
+    })
+
+/** Trigger the layout animation */
+if (skipMs === 0) {
+    await startStats()
+    await client.send("Profiler.start")
+    await page.mouse.click(500, 500)
+} else {
+    await page.mouse.click(500, 500)
+
+    /**
+     * Skip the one-off measure/didUpdate burst at animation start so the
+     * profile captures pure steady-state per-frame work.
+     */
+    await page.waitForTimeout(skipMs)
+
+    await startStats()
+    await client.send("Profiler.start")
+}
+
+await page.waitForTimeout(profileMs)
+
+const { profile } = await client.send("Profiler.stop")
+const stats = await page.evaluate(() =>
+    typeof window.__report === "function" ? window.__report() : null
+)
+
+/** ------------------------------------------------------------------ */
+/** Aggregate the profile                                               */
+/** ------------------------------------------------------------------ */
+
+const nodesById = new Map()
+for (const node of profile.nodes) nodesById.set(node.id, node)
+
+const selfTime = new Map() // key -> µs
+let totalSampled = 0
+const totalWallUs = profile.endTime - profile.startTime
+
+for (let i = 0; i < profile.samples.length; i++) {
+    const delta = profile.timeDeltas[i] ?? 0
+    const node = nodesById.get(profile.samples[i])
+    if (!node) continue
+    const { functionName, url, lineNumber } = node.callFrame
+    if (functionName === "(idle)" || functionName === "(program)") continue
+    totalSampled += delta
+    const key = `${functionName || "(anonymous)"} @ ${url
+        .split("/")
+        .slice(-1)} :${lineNumber}`
+    selfTime.set(key, (selfTime.get(key) || 0) + delta)
+}
+
+const sorted = [...selfTime.entries()].sort((a, b) => b[1] - a[1])
+
+/**
+ * Projection functions live in the framer-motion dep bundle; identify them by
+ * name since the bundle is a single file. Names taken from
+ * motion-dom/src/projection/** and geometry utils.
+ */
+const projectionNames =
+    /projection|targetdelta|dirtynodes|calcprojection|calcrelative|calcboxdelta|calcaxisdelta|removeboxtransforms|applyboxdelta|applyaxisdelta|applytreedelta|boxequal|axisequal|aspectratio|translateaxis|transformbox|scalepoint|applypointdelta|hasscale|has2dtranslate|hastransform|buildprojectiontransform|measure|measurepagebox|measureviewportbox|convertboundingbox|updateprojection|updatelayout|updatesnapshot|notifylayoutupdate|resetskewandrotation|mixaxisdelta|mixbox|mixaxis|snapshot/i
+
+let projectionUs = 0
+for (const [key, us] of selfTime) {
+    if (projectionNames.test(key)) projectionUs += us
+}
+
+const out = {
+    example,
+    profileMs,
+    fps: stats ? stats.frameloop.rate : undefined,
+    projectionMetricsPerFrame: stats
+        ? {
+              nodes: stats.layoutProjection.nodes,
+              calculatedTargetDeltas:
+                  stats.layoutProjection.calculatedTargetDeltas,
+              calculatedProjections:
+                  stats.layoutProjection.calculatedProjections,
+          }
+        : undefined,
+    animations: stats ? stats.animations : undefined,
+    js: {
+        totalSampledMs: +(totalSampled / 1000).toFixed(1),
+        wallMs: +(totalWallUs / 1000).toFixed(1),
+        jsShareOfWall: +((totalSampled / totalWallUs) * 100).toFixed(1) + "%",
+        projectionAttributedMs: +(projectionUs / 1000).toFixed(1),
+        projectionShareOfJS:
+            +((projectionUs / totalSampled) * 100).toFixed(1) + "%",
+    },
+    top30: sorted
+        .slice(0, 30)
+        .map(([key, us]) => `${(us / 1000).toFixed(1).padStart(7)}ms  ${key}`),
+}
+
+console.log(JSON.stringify(out, null, 2))
+writeFileSync(
+    `profile-${example}.json`,
+    JSON.stringify({ out, profile }, null, 0)
+)
+console.log(`\nraw profile written to profile-${example}.json`)
+
+await browser.close()

--- a/dev/react/src/App.tsx
+++ b/dev/react/src/App.tsx
@@ -1,4 +1,12 @@
+import { recordStats } from "framer-motion/debug"
 import { StrictMode } from "react"
+
+/**
+ * Expose Motion's stats recorder for benchmarking/automation.
+ * Usage from devtools or a driver:
+ *   window.__report = window.recordStats(); ...; window.__report()
+ */
+;(window as any).recordStats = recordStats
 
 const examples = import.meta.glob("./examples/*.tsx", {
     eager: true,

--- a/dev/react/src/examples/layout-stress-deep.tsx
+++ b/dev/react/src/examples/layout-stress-deep.tsx
@@ -1,0 +1,57 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+
+/**
+ * Deep-tree layout stress test: many chains of deeply nested projecting
+ * nodes. Exercises the per-node ancestor-path cost of projection
+ * calculation (O(nodes × depth) with per-node path walks vs O(nodes)
+ * with cumulative path transforms).
+ */
+
+const DEPTH = 30
+const CHAINS = 40
+
+function Chain({ depth }: { depth: number }) {
+    if (depth === 0) return null
+    return (
+        <motion.div
+            layout
+            style={{
+                backgroundColor: `hsl(${depth * 12}, 50%, 50%)`,
+                padding: "2px",
+                width: "var(--width)",
+                minHeight: "4px",
+            }}
+        >
+            <Chain depth={depth - 1} />
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <div
+                data-layout
+                style={
+                    {
+                        display: "flex",
+                        flexWrap: "wrap",
+                        width: "1400px",
+                        minHeight: "2000px",
+                        alignItems: "flex-start",
+                        "--width": expanded ? "30px" : "10px",
+                    } as React.CSSProperties
+                }
+                onClick={() => setExpanded(!expanded)}
+            >
+                {Array.from({ length: CHAINS }, (_, i) => (
+                    <Chain key={i} depth={DEPTH} />
+                ))}
+            </div>
+        </MotionConfig>
+    )
+}


### PR DESCRIPTION
## Summary

- `dev/html/public/benchmarks`: interactive benchmarks comparing renderer strategies (inline style writes, adopted stylesheet, registered CSS variables, WAAPI, CSS transitions, GSAP) in benign and hostile style-recalculation environments, plus `style-recalc-harness.html`, which isolates which selector/environment patterns (`[style*=…]` attribute selectors, inherited properties, `@container style()` queries) turn a single style-attribute write into a full-page recalculation.
- `FINDINGS.md`: measured results and methodology — what triggers recalculation bombs, renderer comparisons, and measurement pitfalls (vsync floor masking real cost, rAF throttling in occluded tabs, tween semantics differences between libraries).
- `dev/react/profile-layout.mjs`: Playwright/CDP V8 sampling profiler for the layout stress examples, reporting projection-attributed JS time and per-function self-time hotspots. Works with both the current minimal `recordStats` and newer reporter-returning versions.
- `layout-stress-deep` example: deep-tree (depth 30 × 40 chains) layout animation stress test exercising per-ancestor projection cost.

No library code changes — dev/test tooling only.

## Test plan

- [x] Benchmarks and harness run in Chrome (results documented in FINDINGS.md)
- [x] Profiler smoke-tested against `layout-stress-deep` and `layout-stress-transform` on main