### PR TITLE
Batch projection renders into a single root sweep

### DIFF
--- a/packages/motion-dom/src/projection/node/create-projection-node.ts
+++ b/packages/motion-dom/src/projection/node/create-projection-node.ts
@@ -1560,8 +1560,21 @@ export function createProjectionNode<I>({
             // TODO: Schedule render
         }
 
+        /**
+         * Set when this node needs re-rendering. Consumed by the root's
+         * render sweep, which renders all flagged nodes in a single
+         * frame callback. During layout animations every projecting
+         * node schedules a render every frame, so flag-and-sweep
+         * replaces ~n frameloop scheduling calls per frame with one.
+         */
+        needsRender = false
+        renderSweepScheduled = false
+
         scheduleRender(notifyAll = true) {
-            this.options.visualElement?.scheduleRender()
+            if (this.options.visualElement) {
+                this.needsRender = true
+                this.root.scheduleRenderSweep()
+            }
             if (notifyAll) {
                 const stack = this.getStack()
                 stack && stack.scheduleRender()
@@ -1569,6 +1582,19 @@ export function createProjectionNode<I>({
             if (this.resumingFrom && !this.resumingFrom.instance) {
                 this.resumingFrom = undefined
             }
+        }
+
+        /** Root only */
+        scheduleRenderSweep() {
+            if (!this.renderSweepScheduled) {
+                this.renderSweepScheduled = true
+                frame.render(this.renderSweep, false, true)
+            }
+        }
+
+        renderSweep = () => {
+            this.renderSweepScheduled = false
+            this.nodes && this.nodes.forEach(renderFlaggedNode)
         }
 
         createProjectionDeltas() {
@@ -2284,6 +2310,13 @@ function notifyLayoutUpdate(node: IProjectionNode) {
      * and why we need it at all
      */
     node.options.transition = undefined
+}
+
+function renderFlaggedNode(node: IProjectionNode) {
+    if (node.needsRender) {
+        node.needsRender = false
+        node.options.visualElement?.flushRender()
+    }
 }
 
 export function propagateDirtyNodes(node: IProjectionNode) {

--- a/packages/motion-dom/src/projection/node/types.ts
+++ b/packages/motion-dom/src/projection/node/types.ts
@@ -112,6 +112,13 @@ export interface IProjectionNode<I = unknown> {
         targetStyle: CSSStyleDeclaration,
         styleProp?: MotionStyle
     ): void
+    /**
+     * Set when this node needs re-rendering. Consumed by the root's
+     * render sweep (scheduleRenderSweep), which renders all flagged
+     * nodes in a single frame callback.
+     */
+    needsRender: boolean
+    scheduleRenderSweep(): void
     clearMeasurements(): void
     resetTree(): void
 

--- a/packages/motion-dom/src/render/VisualElement.ts
+++ b/packages/motion-dom/src/render/VisualElement.ts
@@ -688,6 +688,23 @@ export abstract class VisualElement<
     }
 
     /**
+     * Render immediately, unless a render is already scheduled this
+     * frame (in which case that render will perform the same work).
+     * Called by the projection render sweep, which batches the renders
+     * of all projecting nodes into a single frame callback rather than
+     * scheduling one per node per frame. Stamping renderScheduledAt
+     * keeps the semantics identical to scheduleRender: later
+     * same-frame schedules are skipped either way.
+     */
+    flushRender = () => {
+        const now = time.now()
+        if (this.renderScheduledAt < now) {
+            this.renderScheduledAt = now
+            this.render()
+        }
+    }
+
+    /**
      * Measure the current viewport box with or without transforms.
      * Only measures axis-aligned boxes, rotate and skew must be manually
      * removed with a re-render to work.


### PR DESCRIPTION
## Summary

- During layout animations every projecting node schedules its own `frame.render` callback every frame — ~1,500 `schedule()` calls per frame on the `layout-stress-transform` stress example, plus per-callback queue overhead in the frameloop.
- Nodes now set a `needsRender` flag and the projection root schedules **one** frame callback that sweeps the tree (depth-ordered) and renders flagged nodes.
- The new `VisualElement.flushRender()` stamps the same `renderScheduledAt` guard as `scheduleRender()`, so same-frame dedupe semantics are unchanged: if a render is already queued this frame the sweep skips the node (that render includes projection styles), and later same-frame schedules are skipped exactly as before.

Measured via interleaved A/B against main (alternating fresh builds/boots, build-content verified per arm, `layout-stress-transform`, 1,513 nodes): frameloop self-time (schedule + triggerCallback + process) roughly halved, ~65ms → ~25–40ms per 2.4s animation window (~5–10% of total sampled JS).

## Test plan

- [x] `motion-dom` + `framer-motion` unit suites (508 + 814 passing)
- [x] All layout Cypress specs (`layout*.ts`, 68 tests) against React 18
- [x] Interleaved A/B profiling vs main with per-arm build verification